### PR TITLE
Merge consensus routing and time service improvements

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1245,6 +1245,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "axum",
+ "ed25519-dalek",
  "futures",
  "hex",
  "ippan-p2p",
@@ -1270,6 +1271,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sled",
+ "tempfile",
  "thiserror 1.0.69",
  "tracing",
 ]
@@ -1279,6 +1281,7 @@ name = "ippan-types"
 version = "0.1.0"
 dependencies = [
  "blake3",
+ "ed25519-dalek",
  "hex",
  "once_cell",
  "parking_lot 0.12.4",

--- a/crates/crypto/src/lib.rs
+++ b/crates/crypto/src/lib.rs
@@ -1,5 +1,5 @@
 use anyhow::Result;
-use ed25519_dalek::{SigningKey, VerifyingKey, Signature, Signer, Verifier};
+use ed25519_dalek::{Signature, Signer, SigningKey, Verifier, VerifyingKey};
 use rand_core::{OsRng, RngCore};
 
 /// Cryptographic key pair for IPPAN
@@ -17,7 +17,7 @@ impl KeyPair {
         rng.fill_bytes(&mut secret_key);
         let signing_key = SigningKey::from_bytes(&secret_key.into());
         let verifying_key = signing_key.verifying_key();
-        
+
         Self {
             signing_key,
             verifying_key,
@@ -79,7 +79,7 @@ mod tests {
         let keypair = KeyPair::generate();
         let public_key = keypair.public_key();
         let private_key = keypair.private_key();
-        
+
         assert_ne!(public_key, [0u8; 32]);
         assert_ne!(private_key, [0u8; 32]);
     }
@@ -88,10 +88,10 @@ mod tests {
     fn test_signing_and_verification() {
         let keypair = KeyPair::generate();
         let message = b"Hello, IPPAN!";
-        
+
         let signature = keypair.sign(message);
         let result = keypair.verify(message, &signature);
-        
+
         assert!(result.is_ok());
     }
 
@@ -100,7 +100,7 @@ mod tests {
         let data = b"test data";
         let hash1 = CryptoUtils::hash(data);
         let hash2 = CryptoUtils::hash(data);
-        
+
         assert_eq!(hash1, hash2);
         assert_ne!(hash1, [0u8; 32]);
     }

--- a/crates/p2p/src/lib.rs
+++ b/crates/p2p/src/lib.rs
@@ -7,7 +7,7 @@ use std::sync::Arc;
 use std::time::Duration;
 use tokio::sync::mpsc;
 use tokio::time::{interval, sleep};
-use tracing::{info, warn, error, debug};
+use tracing::{debug, error, info, warn};
 use url::Url;
 
 /// P2P network errors
@@ -30,10 +30,17 @@ pub enum P2PError {
 pub enum NetworkMessage {
     Block(Block),
     Transaction(Transaction),
-    BlockRequest { hash: [u8; 32] },
+    BlockRequest {
+        hash: [u8; 32],
+    },
     BlockResponse(Block),
-    PeerInfo { peer_id: String, addresses: Vec<String> },
-    PeerDiscovery { peers: Vec<String> },
+    PeerInfo {
+        peer_id: String,
+        addresses: Vec<String>,
+    },
+    PeerDiscovery {
+        peers: Vec<String>,
+    },
 }
 
 /// Peer information
@@ -85,16 +92,20 @@ pub struct HttpP2PNetwork {
 impl HttpP2PNetwork {
     /// Create a new HTTP P2P network
     pub fn new(config: P2PConfig, local_address: String) -> Result<Self> {
-        let client = Client::builder()
-            .timeout(config.message_timeout)
-            .build()?;
-        
+        let client = Client::builder().timeout(config.message_timeout).build()?;
+
         // Generate a simple peer ID
-        let local_peer_id = format!("ippan-peer-{}", std::time::SystemTime::now().duration_since(std::time::UNIX_EPOCH).unwrap().as_secs());
-        
+        let local_peer_id = format!(
+            "ippan-peer-{}",
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_secs()
+        );
+
         // Create message channels
         let (message_sender, message_receiver) = mpsc::unbounded_channel();
-        
+
         Ok(Self {
             config,
             client,
@@ -107,162 +118,162 @@ impl HttpP2PNetwork {
             local_address,
         })
     }
-    
+
     /// Start the P2P network
     pub async fn start(&mut self) -> Result<()> {
         *self.is_running.write() = true;
         info!("Starting HTTP P2P network on {}", self.local_address);
-        
+
         // Add bootstrap peers
         for peer in &self.config.bootstrap_peers {
             self.add_peer(peer.clone()).await?;
         }
-        
+
         // Start the message processing loop
-        let message_handle = {
+        let _message_handle = {
             let is_running = self.is_running.clone();
             let peers = self.peers.clone();
             let client = self.client.clone();
             let config = self.config.clone();
             let mut message_receiver = self.message_receiver.take().unwrap();
-            
+
             tokio::spawn(async move {
                 loop {
                     if !*is_running.read() {
                         break;
                     }
-                    
+
                     // Process outgoing messages
                     if let Some(msg) = message_receiver.recv().await {
                         Self::handle_outgoing_message(&client, &peers, &config, msg).await;
                     }
-                    
+
                     // Small delay to prevent busy waiting
                     sleep(Duration::from_millis(10)).await;
                 }
             })
         };
-        
+
         // Start peer discovery loop
-        let discovery_handle = {
+        let _discovery_handle = {
             let is_running = self.is_running.clone();
             let peers = self.peers.clone();
             let client = self.client.clone();
             let config = self.config.clone();
             let local_address = self.local_address.clone();
-            
+
             tokio::spawn(async move {
                 let mut interval = interval(config.peer_discovery_interval);
-                
+
                 loop {
                     if !*is_running.read() {
                         break;
                     }
-                    
+
                     interval.tick().await;
-                    Self::discover_peers(&client, &peers, &config, &local_address).await;
+                    Self::discover_peers(&client, &peers, &local_address).await;
                 }
             })
         };
-        
+
         info!("HTTP P2P network started");
         Ok(())
     }
-    
+
     /// Stop the P2P network
-    pub async fn stop(&mut self) -> Result<()> {
+    pub async fn stop(&self) -> Result<()> {
         *self.is_running.write() = false;
         info!("Stopping HTTP P2P network");
-        
+
         // Wait a bit for the network loops to finish
         sleep(Duration::from_millis(100)).await;
-        
+
         info!("HTTP P2P network stopped");
         Ok(())
     }
-    
+
     /// Add a peer to the network
     pub async fn add_peer(&self, peer_address: String) -> Result<()> {
         // Validate URL
         let _url: Url = peer_address.parse()?;
-        
+
         // Add to peers set
         {
             let mut peers = self.peers.write();
             peers.insert(peer_address.clone());
         }
-        
+
         // Update peer count
         {
             let mut count = self.peer_count.write();
             *count = self.peers.read().len();
         }
-        
+
         info!("Added peer: {}", peer_address);
         Ok(())
     }
-    
+
     /// Remove a peer from the network
     pub fn remove_peer(&self, peer_address: &str) {
         {
             let mut peers = self.peers.write();
             peers.remove(peer_address);
         }
-        
+
         {
             let mut count = self.peer_count.write();
             *count = self.peers.read().len();
         }
-        
+
         info!("Removed peer: {}", peer_address);
     }
-    
+
     /// Get message sender for sending messages
     pub fn get_message_sender(&self) -> mpsc::UnboundedSender<NetworkMessage> {
         self.message_sender.clone()
     }
-    
+
     /// Get current peer count
     pub fn get_peer_count(&self) -> usize {
         *self.peer_count.read()
     }
-    
+
     /// Get local peer ID
     pub fn get_local_peer_id(&self) -> String {
         self.local_peer_id.clone()
     }
-    
+
     /// Get listening address
     pub fn get_listening_address(&self) -> String {
         self.local_address.clone()
     }
-    
+
     /// Get list of peers
     pub fn get_peers(&self) -> Vec<String> {
         self.peers.read().iter().cloned().collect()
     }
-    
+
     /// Broadcast a block to all peers
     pub async fn broadcast_block(&self, block: Block) -> Result<()> {
         let message = NetworkMessage::Block(block);
         self.message_sender.send(message)?;
         Ok(())
     }
-    
+
     /// Broadcast a transaction to all peers
     pub async fn broadcast_transaction(&self, tx: Transaction) -> Result<()> {
         let message = NetworkMessage::Transaction(tx);
         self.message_sender.send(message)?;
         Ok(())
     }
-    
+
     /// Request a block from peers
     pub async fn request_block(&self, hash: [u8; 32]) -> Result<()> {
         let message = NetworkMessage::BlockRequest { hash };
         self.message_sender.send(message)?;
         Ok(())
     }
-    
+
     /// Handle outgoing messages by sending them to all peers
     async fn handle_outgoing_message(
         client: &Client,
@@ -271,20 +282,22 @@ impl HttpP2PNetwork {
         message: NetworkMessage,
     ) {
         let peer_list = peers.read().clone();
-        
+
         for peer_address in peer_list {
             let client = client.clone();
             let message = message.clone();
             let config = config.clone();
-            
+
             tokio::spawn(async move {
-                if let Err(e) = Self::send_message_to_peer(&client, &peer_address, &message, &config).await {
+                if let Err(e) =
+                    Self::send_message_to_peer(&client, &peer_address, &message, &config).await
+                {
                     warn!("Failed to send message to peer {}: {}", peer_address, e);
                 }
             });
         }
     }
-    
+
     /// Send a message to a specific peer
     async fn send_message_to_peer(
         client: &Client,
@@ -300,9 +313,9 @@ impl HttpP2PNetwork {
             NetworkMessage::PeerInfo { .. } => "/p2p/peer-info",
             NetworkMessage::PeerDiscovery { .. } => "/p2p/peer-discovery",
         };
-        
+
         let url = format!("{}{}", peer_address, endpoint);
-        
+
         for attempt in 1..=config.retry_attempts {
             match client.post(&url).json(message).send().await {
                 Ok(response) => {
@@ -310,59 +323,74 @@ impl HttpP2PNetwork {
                         debug!("Successfully sent message to peer {}", peer_address);
                         return Ok(());
                     } else {
-                        warn!("Peer {} returned status: {}", peer_address, response.status());
+                        warn!(
+                            "Peer {} returned status: {}",
+                            peer_address,
+                            response.status()
+                        );
                     }
                 }
                 Err(e) => {
                     if attempt == config.retry_attempts {
-                        return Err(P2PError::Peer(format!("Failed to send to {} after {} attempts: {}", peer_address, config.retry_attempts, e)).into());
+                        return Err(P2PError::Peer(format!(
+                            "Failed to send to {} after {} attempts: {}",
+                            peer_address, config.retry_attempts, e
+                        ))
+                        .into());
                     }
-                    warn!("Attempt {} failed for peer {}: {}", attempt, peer_address, e);
+                    warn!(
+                        "Attempt {} failed for peer {}: {}",
+                        attempt, peer_address, e
+                    );
                     sleep(Duration::from_millis(100 * attempt as u64)).await;
                 }
             }
         }
-        
+
         Ok(())
     }
-    
+
     /// Discover new peers by asking existing peers
     async fn discover_peers(
         client: &Client,
         peers: &Arc<parking_lot::RwLock<HashSet<String>>>,
-        config: &P2PConfig,
         local_address: &str,
     ) {
         let peer_list = peers.read().clone();
-        
+
         for peer_address in peer_list {
             let client = client.clone();
             let peers = peers.clone();
-            let config = config.clone();
             let local_address = local_address.to_string();
-            
+
             tokio::spawn(async move {
-                if let Err(e) = Self::request_peers_from_peer(&client, &peer_address, &peers, &config, &local_address).await {
+                if let Err(e) = Self::request_peers_from_peer(
+                    &client,
+                    &peer_address,
+                    &peers,
+                    &local_address,
+                )
+                .await
+                {
                     debug!("Failed to discover peers from {}: {}", peer_address, e);
                 }
             });
         }
     }
-    
+
     /// Request peer list from a specific peer
     async fn request_peers_from_peer(
         client: &Client,
         peer_address: &str,
         peers: &Arc<parking_lot::RwLock<HashSet<String>>>,
-        config: &P2PConfig,
         local_address: &str,
     ) -> Result<()> {
         let url = format!("{}/p2p/peers", peer_address);
-        
+
         let response = client.get(&url).send().await?;
         if response.status().is_success() {
             let peer_list: Vec<String> = response.json().await?;
-            
+
             // Add new peers (excluding ourselves)
             let mut current_peers = peers.write();
             for peer in peer_list {
@@ -372,7 +400,7 @@ impl HttpP2PNetwork {
                 }
             }
         }
-        
+
         Ok(())
     }
 }
@@ -387,33 +415,39 @@ mod tests {
         let network = HttpP2PNetwork::new(config, "http://localhost:9000".to_string());
         assert!(network.is_ok());
     }
-    
+
     #[test]
     fn test_network_message_serialization() {
         let block = Block::new([0u8; 32], vec![], 1, [1u8; 32]);
         let message = NetworkMessage::Block(block);
-        
+
         let serialized = serde_json::to_vec(&message).unwrap();
         let deserialized: NetworkMessage = serde_json::from_slice(&serialized).unwrap();
-        
+
         match deserialized {
             NetworkMessage::Block(_) => {}
             _ => panic!("Expected Block message"),
         }
     }
-    
+
     #[tokio::test]
     async fn test_peer_management() {
         let config = P2PConfig::default();
         let network = HttpP2PNetwork::new(config, "http://localhost:9000".to_string()).unwrap();
-        
+
         // Test adding peers
-        network.add_peer("http://localhost:9001".to_string()).await.unwrap();
-        network.add_peer("http://localhost:9002".to_string()).await.unwrap();
-        
+        network
+            .add_peer("http://localhost:9001".to_string())
+            .await
+            .unwrap();
+        network
+            .add_peer("http://localhost:9002".to_string())
+            .await
+            .unwrap();
+
         assert_eq!(network.get_peer_count(), 2);
         assert_eq!(network.get_peers().len(), 2);
-        
+
         // Test removing peers
         network.remove_peer("http://localhost:9001");
         assert_eq!(network.get_peer_count(), 1);

--- a/crates/rpc/Cargo.toml
+++ b/crates/rpc/Cargo.toml
@@ -20,3 +20,6 @@ axum = { workspace = true }
 tower = { workspace = true }
 tower-http = { workspace = true }
 futures = { workspace = true }
+
+[dev-dependencies]
+ed25519-dalek = { workspace = true }

--- a/crates/rpc/src/lib.rs
+++ b/crates/rpc/src/lib.rs
@@ -6,20 +6,20 @@ use axum::{
     routing::{get, post},
     Router,
 };
-use ippan_storage::{Storage, Account};
-use ippan_types::{Transaction, Block, ippan_time_now};
+use ippan_storage::Storage;
+use ippan_types::{ippan_time_now, Block, Transaction};
 use serde::{Deserialize, Serialize};
-use std::collections::HashMap;
 use std::sync::Arc;
+use tokio::sync::mpsc::UnboundedSender;
 use tower::ServiceBuilder;
 use tower_http::{
     cors::{Any, CorsLayer},
     trace::TraceLayer,
 };
-use tracing::{info, error, warn};
+use tracing::{error, info, warn};
 
 /// RPC response wrapper
-#[derive(Debug, Serialize)]
+#[derive(Debug, Serialize, Deserialize)]
 pub struct RpcResponse<T> {
     pub success: bool,
     pub data: Option<T>,
@@ -34,7 +34,7 @@ impl<T> RpcResponse<T> {
             error: None,
         }
     }
-    
+
     pub fn error(message: String) -> Self {
         Self {
             success: false,
@@ -44,18 +44,8 @@ impl<T> RpcResponse<T> {
     }
 }
 
-/// Submit transaction request
-#[derive(Debug, Deserialize)]
-pub struct SubmitTransactionRequest {
-    pub from: String,
-    pub to: String,
-    pub amount: u64,
-    pub nonce: u64,
-    pub signature: String,
-}
-
 /// Submit transaction response
-#[derive(Debug, Serialize)]
+#[derive(Debug, Serialize, Deserialize)]
 pub struct SubmitTransactionResponse {
     pub tx_hash: String,
 }
@@ -76,7 +66,7 @@ pub struct GetAccountResponse {
 }
 
 /// Get time response
-#[derive(Debug, Serialize)]
+#[derive(Debug, Serialize, Deserialize)]
 pub struct GetTimeResponse {
     pub time_us: u64,
 }
@@ -91,7 +81,7 @@ pub struct NodeStatusResponse {
 }
 
 /// Health check response
-#[derive(Debug, Serialize)]
+#[derive(Debug, Serialize, Deserialize)]
 pub struct HealthResponse {
     pub status: String,
     pub timestamp: u64,
@@ -104,6 +94,7 @@ pub struct AppState {
     pub start_time: std::time::Instant,
     pub peer_count: Arc<std::sync::atomic::AtomicUsize>,
     pub p2p_network: Option<Arc<ippan_p2p::HttpP2PNetwork>>,
+    pub tx_sender: Option<UnboundedSender<Transaction>>,
 }
 
 /// Create the Axum router with all RPC endpoints
@@ -113,18 +104,15 @@ pub fn create_router(state: AppState) -> Router {
         .route("/health", get(health_check))
         .route("/status", get(node_status))
         .route("/time", get(get_time))
-        
         // Blockchain endpoints
         .route("/block", get(get_block))
         .route("/block/:hash", get(get_block_by_hash))
         .route("/block/height/:height", get(get_block_by_height))
         .route("/tx", post(submit_transaction))
         .route("/tx/:hash", get(get_transaction))
-        
         // Account endpoints
         .route("/account/:address", get(get_account))
         .route("/accounts", get(get_all_accounts))
-        
         // P2P endpoints
         .route("/p2p/blocks", post(receive_block))
         .route("/p2p/transactions", post(receive_transaction))
@@ -133,18 +121,22 @@ pub fn create_router(state: AppState) -> Router {
         .route("/p2p/peer-info", post(receive_peer_info))
         .route("/p2p/peer-discovery", post(receive_peer_discovery))
         .route("/p2p/peers", get(get_peers))
-        
         // Add middleware
         .layer(
             ServiceBuilder::new()
                 .layer(TraceLayer::new_for_http())
-                .layer(CorsLayer::new().allow_origin(Any).allow_methods(Any).allow_headers(Any))
+                .layer(
+                    CorsLayer::new()
+                        .allow_origin(Any)
+                        .allow_methods(Any)
+                        .allow_headers(Any),
+                ),
         )
         .with_state(state)
 }
 
 /// Health check endpoint
-async fn health_check(State(state): State<AppState>) -> Json<RpcResponse<HealthResponse>> {
+async fn health_check(State(_state): State<AppState>) -> Json<RpcResponse<HealthResponse>> {
     let response = HealthResponse {
         status: "healthy".to_string(),
         timestamp: ippan_time_now(),
@@ -153,20 +145,24 @@ async fn health_check(State(state): State<AppState>) -> Json<RpcResponse<HealthR
 }
 
 /// Node status endpoint
-async fn node_status(State(state): State<AppState>) -> Result<Json<RpcResponse<NodeStatusResponse>>, StatusCode> {
-    let latest_height = state.storage.get_latest_height()
+async fn node_status(
+    State(state): State<AppState>,
+) -> Result<Json<RpcResponse<NodeStatusResponse>>, StatusCode> {
+    let latest_height = state
+        .storage
+        .get_latest_height()
         .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
-    
+
     let uptime = state.start_time.elapsed().as_secs();
     let peer_count = state.peer_count.load(std::sync::atomic::Ordering::Relaxed);
-    
+
     let response = NodeStatusResponse {
         version: env!("CARGO_PKG_VERSION").to_string(),
         latest_height,
         uptime_seconds: uptime,
         peer_count,
     };
-    
+
     Ok(Json(RpcResponse::success(response)))
 }
 
@@ -184,25 +180,28 @@ async fn get_block(
     Query(params): Query<GetBlockQuery>,
 ) -> Result<Json<RpcResponse<Option<Block>>>, StatusCode> {
     let block = if let Some(hash_str) = params.hash {
-        let hash = hex::decode(&hash_str)
-            .map_err(|_| StatusCode::BAD_REQUEST)?;
-        
+        let hash = hex::decode(&hash_str).map_err(|_| StatusCode::BAD_REQUEST)?;
+
         if hash.len() != 32 {
             return Err(StatusCode::BAD_REQUEST);
         }
-        
+
         let mut hash_bytes = [0u8; 32];
         hash_bytes.copy_from_slice(&hash);
-        
-        state.storage.get_block(&hash_bytes)
+
+        state
+            .storage
+            .get_block(&hash_bytes)
             .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?
     } else if let Some(height) = params.height {
-        state.storage.get_block_by_height(height)
+        state
+            .storage
+            .get_block_by_height(height)
             .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?
     } else {
         return Err(StatusCode::BAD_REQUEST);
     };
-    
+
     Ok(Json(RpcResponse::success(block)))
 }
 
@@ -211,19 +210,20 @@ async fn get_block_by_hash(
     State(state): State<AppState>,
     Path(hash_str): Path<String>,
 ) -> Result<Json<RpcResponse<Option<Block>>>, StatusCode> {
-    let hash = hex::decode(&hash_str)
-        .map_err(|_| StatusCode::BAD_REQUEST)?;
-    
+    let hash = hex::decode(&hash_str).map_err(|_| StatusCode::BAD_REQUEST)?;
+
     if hash.len() != 32 {
         return Err(StatusCode::BAD_REQUEST);
     }
-    
+
     let mut hash_bytes = [0u8; 32];
     hash_bytes.copy_from_slice(&hash);
-    
-    let block = state.storage.get_block(&hash_bytes)
+
+    let block = state
+        .storage
+        .get_block(&hash_bytes)
         .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
-    
+
     Ok(Json(RpcResponse::success(block)))
 }
 
@@ -232,54 +232,60 @@ async fn get_block_by_height(
     State(state): State<AppState>,
     Path(height): Path<u64>,
 ) -> Result<Json<RpcResponse<Option<Block>>>, StatusCode> {
-    let block = state.storage.get_block_by_height(height)
+    let block = state
+        .storage
+        .get_block_by_height(height)
         .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
-    
+
     Ok(Json(RpcResponse::success(block)))
 }
 
 /// Submit a transaction
 async fn submit_transaction(
     State(state): State<AppState>,
-    Json(request): Json<SubmitTransactionRequest>,
+    Json(mut tx): Json<Transaction>,
 ) -> Result<Json<RpcResponse<SubmitTransactionResponse>>, StatusCode> {
-    // Parse addresses
-    let from = hex::decode(&request.from)
-        .map_err(|_| StatusCode::BAD_REQUEST)?;
-    let to = hex::decode(&request.to)
-        .map_err(|_| StatusCode::BAD_REQUEST)?;
-    let signature = hex::decode(&request.signature)
-        .map_err(|_| StatusCode::BAD_REQUEST)?;
-    
-    if from.len() != 32 || to.len() != 32 || signature.len() != 64 {
-        return Err(StatusCode::BAD_REQUEST);
+    // Ensure transaction identifier reflects the provided contents
+    let computed_hash = tx.hash();
+    if tx.id != computed_hash {
+        tx.id = computed_hash;
     }
-    
-    let mut from_bytes = [0u8; 32];
-    let mut to_bytes = [0u8; 32];
-    let mut signature_bytes = [0u8; 64];
-    
-    from_bytes.copy_from_slice(&from);
-    to_bytes.copy_from_slice(&to);
-    signature_bytes.copy_from_slice(&signature);
-    
-    // Create transaction
-    let mut tx = Transaction::new(from_bytes, to_bytes, request.amount, request.nonce);
-    tx.signature = signature_bytes;
-    
-    // Validate transaction
+
+    // Validate transaction before accepting it
     if !tx.is_valid() {
+        warn!("Rejected invalid transaction from {}", hex::encode(tx.from));
         return Err(StatusCode::BAD_REQUEST);
     }
-    
-    // Store transaction
-    state.storage.store_transaction(tx.clone())
+
+    // Store transaction locally
+    state
+        .storage
+        .store_transaction(tx.clone())
         .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
-    
+
+    // Submit to the consensus mempool if available
+    if let Some(sender) = &state.tx_sender {
+        if let Err(error) = sender.send(tx.clone()) {
+            error!("Failed to forward transaction to consensus: {}", error);
+            return Err(StatusCode::INTERNAL_SERVER_ERROR);
+        }
+    }
+
+    // Broadcast the transaction to peers if networking is available
+    if let Some(network) = &state.p2p_network {
+        if let Err(error) = network.broadcast_transaction(tx.clone()).await {
+            warn!(
+                "Failed to broadcast transaction {}: {}",
+                hex::encode(tx.id),
+                error
+            );
+        }
+    }
+
     let response = SubmitTransactionResponse {
-        tx_hash: hex::encode(tx.hash()),
+        tx_hash: hex::encode(tx.id),
     };
-    
+
     info!("Submitted transaction: {}", response.tx_hash);
     Ok(Json(RpcResponse::success(response)))
 }
@@ -289,19 +295,20 @@ async fn get_transaction(
     State(state): State<AppState>,
     Path(hash_str): Path<String>,
 ) -> Result<Json<RpcResponse<Option<Transaction>>>, StatusCode> {
-    let hash = hex::decode(&hash_str)
-        .map_err(|_| StatusCode::BAD_REQUEST)?;
-    
+    let hash = hex::decode(&hash_str).map_err(|_| StatusCode::BAD_REQUEST)?;
+
     if hash.len() != 32 {
         return Err(StatusCode::BAD_REQUEST);
     }
-    
+
     let mut hash_bytes = [0u8; 32];
     hash_bytes.copy_from_slice(&hash);
-    
-    let tx = state.storage.get_transaction(&hash_bytes)
+
+    let tx = state
+        .storage
+        .get_transaction(&hash_bytes)
         .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
-    
+
     Ok(Json(RpcResponse::success(tx)))
 }
 
@@ -310,25 +317,26 @@ async fn get_account(
     State(state): State<AppState>,
     Path(address_str): Path<String>,
 ) -> Result<Json<RpcResponse<Option<GetAccountResponse>>>, StatusCode> {
-    let address = hex::decode(&address_str)
-        .map_err(|_| StatusCode::BAD_REQUEST)?;
-    
+    let address = hex::decode(&address_str).map_err(|_| StatusCode::BAD_REQUEST)?;
+
     if address.len() != 32 {
         return Err(StatusCode::BAD_REQUEST);
     }
-    
+
     let mut address_bytes = [0u8; 32];
     address_bytes.copy_from_slice(&address);
-    
-    let account = state.storage.get_account(&address_bytes)
+
+    let account = state
+        .storage
+        .get_account(&address_bytes)
         .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
-    
+
     let response = account.map(|acc| GetAccountResponse {
         address: address_str,
         balance: acc.balance,
         nonce: acc.nonce,
     });
-    
+
     Ok(Json(RpcResponse::success(response)))
 }
 
@@ -336,17 +344,20 @@ async fn get_account(
 async fn get_all_accounts(
     State(state): State<AppState>,
 ) -> Result<Json<RpcResponse<Vec<GetAccountResponse>>>, StatusCode> {
-    let accounts = state.storage.get_all_accounts()
+    let accounts = state
+        .storage
+        .get_all_accounts()
         .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
-    
-    let response: Vec<GetAccountResponse> = accounts.into_iter().map(|acc| {
-        GetAccountResponse {
+
+    let response: Vec<GetAccountResponse> = accounts
+        .into_iter()
+        .map(|acc| GetAccountResponse {
             address: hex::encode(acc.address),
             balance: acc.balance,
             nonce: acc.nonce,
-        }
-    }).collect();
-    
+        })
+        .collect();
+
     Ok(Json(RpcResponse::success(response)))
 }
 
@@ -355,12 +366,20 @@ async fn receive_block(
     State(state): State<AppState>,
     Json(block): Json<Block>,
 ) -> Result<Json<RpcResponse<String>>, StatusCode> {
+    if !block.is_valid() {
+        warn!(
+            "Rejected invalid block from peer: {}",
+            hex::encode(block.hash())
+        );
+        return Err(StatusCode::BAD_REQUEST);
+    }
+
     // Store the received block
     if let Err(e) = state.storage.store_block(block.clone()) {
         error!("Failed to store received block: {}", e);
         return Err(StatusCode::INTERNAL_SERVER_ERROR);
     }
-    
+
     info!("Received block from peer: {}", hex::encode(block.hash()));
     Ok(Json(RpcResponse::success("Block received".to_string())))
 }
@@ -370,14 +389,33 @@ async fn receive_transaction(
     State(state): State<AppState>,
     Json(tx): Json<Transaction>,
 ) -> Result<Json<RpcResponse<String>>, StatusCode> {
+    if !tx.is_valid() {
+        warn!(
+            "Rejected invalid transaction from peer: {}",
+            hex::encode(tx.hash())
+        );
+        return Err(StatusCode::BAD_REQUEST);
+    }
+
     // Store the received transaction
     if let Err(e) = state.storage.store_transaction(tx.clone()) {
         error!("Failed to store received transaction: {}", e);
         return Err(StatusCode::INTERNAL_SERVER_ERROR);
     }
-    
+
+    if let Some(sender) = &state.tx_sender {
+        if let Err(error) = sender.send(tx.clone()) {
+            error!(
+                "Failed to forward received transaction to consensus: {}",
+                error
+            );
+        }
+    }
+
     info!("Received transaction from peer: {}", hex::encode(tx.hash()));
-    Ok(Json(RpcResponse::success("Transaction received".to_string())))
+    Ok(Json(RpcResponse::success(
+        "Transaction received".to_string(),
+    )))
 }
 
 /// P2P endpoint: Receive block request from peer
@@ -387,10 +425,12 @@ async fn receive_block_request(
 ) -> Result<Json<RpcResponse<String>>, StatusCode> {
     if let ippan_p2p::NetworkMessage::BlockRequest { hash } = request {
         // Try to find the requested block
-        if let Ok(Some(block)) = state.storage.get_block(&hash) {
+        if let Ok(Some(_block)) = state.storage.get_block(&hash) {
             // In a real implementation, we would send the block back to the requesting peer
             info!("Block request received for: {}", hex::encode(hash));
-            Ok(Json(RpcResponse::success("Block request processed".to_string())))
+            Ok(Json(RpcResponse::success(
+                "Block request processed".to_string(),
+            )))
         } else {
             warn!("Block not found for request: {}", hex::encode(hash));
             Err(StatusCode::NOT_FOUND)
@@ -406,14 +446,24 @@ async fn receive_block_response(
     Json(response): Json<ippan_p2p::NetworkMessage>,
 ) -> Result<Json<RpcResponse<String>>, StatusCode> {
     if let ippan_p2p::NetworkMessage::BlockResponse(block) = response {
+        if !block.is_valid() {
+            warn!(
+                "Rejected invalid block response from peer: {}",
+                hex::encode(block.hash())
+            );
+            return Err(StatusCode::BAD_REQUEST);
+        }
+
         // Store the received block
         if let Err(e) = state.storage.store_block(block.clone()) {
             error!("Failed to store received block response: {}", e);
             return Err(StatusCode::INTERNAL_SERVER_ERROR);
         }
-        
+
         info!("Received block response: {}", hex::encode(block.hash()));
-        Ok(Json(RpcResponse::success("Block response received".to_string())))
+        Ok(Json(RpcResponse::success(
+            "Block response received".to_string(),
+        )))
     } else {
         Err(StatusCode::BAD_REQUEST)
     }
@@ -425,7 +475,10 @@ async fn receive_peer_info(
     Json(info): Json<ippan_p2p::NetworkMessage>,
 ) -> Result<Json<RpcResponse<String>>, StatusCode> {
     if let ippan_p2p::NetworkMessage::PeerInfo { peer_id, addresses } = info {
-        info!("Received peer info: {} with addresses: {:?}", peer_id, addresses);
+        info!(
+            "Received peer info: {} with addresses: {:?}",
+            peer_id, addresses
+        );
         Ok(Json(RpcResponse::success("Peer info received".to_string())))
     } else {
         Err(StatusCode::BAD_REQUEST)
@@ -439,7 +492,9 @@ async fn receive_peer_discovery(
 ) -> Result<Json<RpcResponse<String>>, StatusCode> {
     if let ippan_p2p::NetworkMessage::PeerDiscovery { peers } = discovery {
         info!("Received peer discovery with {} peers", peers.len());
-        Ok(Json(RpcResponse::success("Peer discovery received".to_string())))
+        Ok(Json(RpcResponse::success(
+            "Peer discovery received".to_string(),
+        )))
     } else {
         Err(StatusCode::BAD_REQUEST)
     }
@@ -458,12 +513,9 @@ async fn get_peers(
 }
 
 /// Start the HTTP server
-pub async fn start_server(
-    state: AppState,
-    addr: &str,
-) -> Result<()> {
+pub async fn start_server(state: AppState, addr: &str) -> Result<()> {
     let app = create_router(state);
-    
+
     let listener = tokio::net::TcpListener::bind(addr).await?;
     info!("RPC server listening on {}", addr);
     info!("Available endpoints:");
@@ -478,37 +530,139 @@ pub async fn start_server(
     info!("  GET  /tx/<hash> - Get transaction by hash");
     info!("  GET  /account/<address> - Get account info");
     info!("  GET  /accounts - Get all accounts");
-    
+
     axum::serve(listener, app).await?;
-    
+
     Ok(())
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use axum::body::{self, Body};
+    use axum::http::{Method, Request, StatusCode};
     use ippan_storage::MemoryStorage;
+    use std::convert::TryFrom;
     use std::sync::atomic::AtomicUsize;
+    use tokio::sync::mpsc;
+    use tower::Service;
+
+    use ed25519_dalek::SigningKey;
 
     #[tokio::test]
     async fn test_health_check() {
-        let storage = Arc::new(MemoryStorage::new());
+        let storage: Arc<dyn Storage + Send + Sync> = Arc::new(MemoryStorage::new());
         let state = AppState {
             storage,
             start_time: std::time::Instant::now(),
             peer_count: Arc::new(AtomicUsize::new(0)),
             p2p_network: None,
+            tx_sender: None,
         };
-        
-        let response = health_check(State(state)).await;
-        assert!(response.success);
-        assert_eq!(response.data.unwrap().status, "healthy");
+
+        let mut app = create_router(state);
+        let response = Service::call(
+            &mut app,
+            Request::builder()
+                .method(Method::GET)
+                .uri("/health")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = body::to_bytes(response.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let rpc_response: RpcResponse<HealthResponse> = serde_json::from_slice(&body).unwrap();
+        assert!(rpc_response.success);
+        assert_eq!(rpc_response.data.unwrap().status, "healthy");
     }
-    
+
     #[tokio::test]
     async fn test_get_time() {
-        let response = get_time().await;
-        assert!(response.success);
-        assert!(response.data.unwrap().time_us > 0);
+        let storage: Arc<dyn Storage + Send + Sync> = Arc::new(MemoryStorage::new());
+        let state = AppState {
+            storage,
+            start_time: std::time::Instant::now(),
+            peer_count: Arc::new(AtomicUsize::new(0)),
+            p2p_network: None,
+            tx_sender: None,
+        };
+
+        let mut app = create_router(state);
+        let response = Service::call(
+            &mut app,
+            Request::builder()
+                .method(Method::GET)
+                .uri("/time")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = body::to_bytes(response.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let rpc_response: RpcResponse<GetTimeResponse> = serde_json::from_slice(&body).unwrap();
+        assert!(rpc_response.success);
+        assert!(rpc_response.data.unwrap().time_us > 0);
+    }
+
+    #[tokio::test]
+    async fn test_submit_transaction_flow() {
+        let storage: Arc<dyn Storage + Send + Sync> = Arc::new(MemoryStorage::new());
+        let (tx_sender, mut tx_receiver) = mpsc::unbounded_channel();
+
+        let state = AppState {
+            storage: storage.clone(),
+            start_time: std::time::Instant::now(),
+            peer_count: Arc::new(AtomicUsize::new(0)),
+            p2p_network: None,
+            tx_sender: Some(tx_sender),
+        };
+
+        let mut app = create_router(state);
+
+        let secret_bytes = [7u8; 32];
+        let signing_key = SigningKey::try_from(&secret_bytes[..]).unwrap();
+        let public_key = signing_key.verifying_key().to_bytes();
+
+        let mut tx = Transaction::new(public_key, [9u8; 32], 500, 0);
+        tx.sign(&secret_bytes).unwrap();
+
+        let body_bytes = serde_json::to_vec(&tx).unwrap();
+
+        let response = Service::call(
+            &mut app,
+            Request::builder()
+                .method(Method::POST)
+                .uri("/tx")
+                .header("content-type", "application/json")
+                .body(Body::from(body_bytes))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+
+        let body = body::to_bytes(response.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let rpc_response: RpcResponse<SubmitTransactionResponse> =
+            serde_json::from_slice(&body).unwrap();
+        assert!(rpc_response.success);
+        assert_eq!(rpc_response.data.unwrap().tx_hash, hex::encode(tx.id));
+
+        let stored = storage.get_transaction(&tx.id).unwrap();
+        assert!(stored.is_some());
+
+        let forwarded = tx_receiver.try_recv().unwrap();
+        assert_eq!(forwarded.id, tx.id);
     }
 }

--- a/crates/storage/Cargo.toml
+++ b/crates/storage/Cargo.toml
@@ -15,3 +15,6 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 parking_lot = { workspace = true }
 tracing = { workspace = true }
+
+[dev-dependencies]
+tempfile = "3"

--- a/crates/storage/src/lib.rs
+++ b/crates/storage/src/lib.rs
@@ -1,11 +1,11 @@
 use anyhow::Result;
 use ippan_types::{Block, Transaction};
+use parking_lot::RwLock;
 use serde::{Deserialize, Serialize};
 use sled::{Db, Tree};
 use std::collections::HashMap;
 use std::path::Path;
 use std::sync::Arc;
-use parking_lot::RwLock;
 
 /// Storage errors
 #[derive(thiserror::Error, Debug)]
@@ -34,28 +34,28 @@ pub struct Account {
 pub trait Storage {
     /// Store a block
     fn store_block(&self, block: Block) -> Result<()>;
-    
+
     /// Get a block by hash
     fn get_block(&self, hash: &[u8; 32]) -> Result<Option<Block>>;
-    
+
     /// Get a block by height
     fn get_block_by_height(&self, height: u64) -> Result<Option<Block>>;
-    
+
     /// Store a transaction
     fn store_transaction(&self, tx: Transaction) -> Result<()>;
-    
+
     /// Get a transaction by hash
     fn get_transaction(&self, hash: &[u8; 32]) -> Result<Option<Transaction>>;
-    
+
     /// Get the latest block height
     fn get_latest_height(&self) -> Result<u64>;
-    
+
     /// Get account information
     fn get_account(&self, address: &[u8; 32]) -> Result<Option<Account>>;
-    
+
     /// Update account information
     fn update_account(&self, account: Account) -> Result<()>;
-    
+
     /// Get all accounts (for debugging/testing)
     fn get_all_accounts(&self) -> Result<Vec<Account>>;
 }
@@ -73,12 +73,12 @@ impl SledStorage {
     /// Create a new Sled storage instance
     pub fn new<P: AsRef<Path>>(path: P) -> Result<Self> {
         let db = sled::open(path)?;
-        
+
         let blocks = db.open_tree("blocks")?;
         let transactions = db.open_tree("transactions")?;
         let accounts = db.open_tree("accounts")?;
         let metadata = db.open_tree("metadata")?;
-        
+
         Ok(Self {
             db,
             blocks,
@@ -87,7 +87,7 @@ impl SledStorage {
             metadata,
         })
     }
-    
+
     /// Initialize with genesis block if needed
     pub fn initialize(&self) -> Result<()> {
         // Check if we already have blocks
@@ -99,9 +99,9 @@ impl SledStorage {
                 0,         // Genesis round
                 [0u8; 32], // Genesis proposer
             );
-            
+
             self.store_block(genesis_block)?;
-            
+
             // Create genesis account with initial balance
             let genesis_account = Account {
                 address: [0u8; 32],
@@ -109,13 +109,13 @@ impl SledStorage {
                 nonce: 0,
             };
             self.update_account(genesis_account)?;
-            
+
             tracing::info!("Initialized with genesis block and account");
         }
-        
+
         Ok(())
     }
-    
+
     /// Flush all pending writes to disk
     pub fn flush(&self) -> Result<()> {
         self.db.flush()?;
@@ -127,13 +127,13 @@ impl Storage for SledStorage {
     fn store_block(&self, block: Block) -> Result<()> {
         let hash = block.hash();
         let height = block.header.round_id;
-        
+
         // Serialize block
         let block_data = serde_json::to_vec(&block)?;
-        
+
         // Store by hash
         self.blocks.insert(&hash[..], block_data.as_slice())?;
-        
+
         // Store by height for quick lookup
         let height_key = height.to_be_bytes();
         let height_prefix = b"height_";
@@ -141,15 +141,16 @@ impl Storage for SledStorage {
         height_key_bytes.extend_from_slice(height_prefix);
         height_key_bytes.extend_from_slice(&height_key);
         self.blocks.insert(&height_key_bytes, &hash[..])?;
-        
+
         // Update latest height
         let latest_height = self.get_latest_height()?.max(height);
-        self.metadata.insert(b"latest_height", &latest_height.to_be_bytes())?;
-        
+        self.metadata
+            .insert(b"latest_height", &latest_height.to_be_bytes())?;
+
         tracing::debug!("Stored block {} at height {}", hex::encode(hash), height);
         Ok(())
     }
-    
+
     fn get_block(&self, hash: &[u8; 32]) -> Result<Option<Block>> {
         if let Some(data) = self.blocks.get(&hash[..])? {
             let block: Block = serde_json::from_slice(&data)?;
@@ -158,14 +159,14 @@ impl Storage for SledStorage {
             Ok(None)
         }
     }
-    
+
     fn get_block_by_height(&self, height: u64) -> Result<Option<Block>> {
         let height_key = height.to_be_bytes();
         let height_prefix = b"height_";
         let mut height_key_bytes = Vec::with_capacity(height_prefix.len() + height_key.len());
         height_key_bytes.extend_from_slice(height_prefix);
         height_key_bytes.extend_from_slice(&height_key);
-        
+
         if let Some(hash_data) = self.blocks.get(&height_key_bytes)? {
             let mut hash = [0u8; 32];
             hash.copy_from_slice(&hash_data);
@@ -174,17 +175,17 @@ impl Storage for SledStorage {
             Ok(None)
         }
     }
-    
+
     fn store_transaction(&self, tx: Transaction) -> Result<()> {
         let hash = tx.hash();
         let tx_data = serde_json::to_vec(&tx)?;
-        
+
         self.transactions.insert(&hash[..], tx_data.as_slice())?;
-        
+
         tracing::debug!("Stored transaction {}", hex::encode(hash));
         Ok(())
     }
-    
+
     fn get_transaction(&self, hash: &[u8; 32]) -> Result<Option<Transaction>> {
         if let Some(data) = self.transactions.get(&hash[..])? {
             let tx: Transaction = serde_json::from_slice(&data)?;
@@ -193,7 +194,7 @@ impl Storage for SledStorage {
             Ok(None)
         }
     }
-    
+
     fn get_latest_height(&self) -> Result<u64> {
         if let Some(data) = self.metadata.get(b"latest_height")? {
             let mut bytes = [0u8; 8];
@@ -203,7 +204,7 @@ impl Storage for SledStorage {
             Ok(0)
         }
     }
-    
+
     fn get_account(&self, address: &[u8; 32]) -> Result<Option<Account>> {
         if let Some(data) = self.accounts.get(&address[..])? {
             let account: Account = serde_json::from_slice(&data)?;
@@ -212,25 +213,29 @@ impl Storage for SledStorage {
             Ok(None)
         }
     }
-    
+
     fn update_account(&self, account: Account) -> Result<()> {
         let account_data = serde_json::to_vec(&account)?;
-        self.accounts.insert(&account.address[..], account_data.as_slice())?;
-        
-        tracing::debug!("Updated account {} with balance {}", 
-            hex::encode(account.address), account.balance);
+        self.accounts
+            .insert(&account.address[..], account_data.as_slice())?;
+
+        tracing::debug!(
+            "Updated account {} with balance {}",
+            hex::encode(account.address),
+            account.balance
+        );
         Ok(())
     }
-    
+
     fn get_all_accounts(&self) -> Result<Vec<Account>> {
         let mut accounts = Vec::new();
-        
+
         for result in self.accounts.iter() {
             let (_, data) = result?;
             let account: Account = serde_json::from_slice(&data)?;
             accounts.push(account);
         }
-        
+
         Ok(accounts)
     }
 }
@@ -258,50 +263,55 @@ impl Storage for MemoryStorage {
     fn store_block(&self, block: Block) -> Result<()> {
         let hash = block.hash();
         let hash_str = hex::encode(hash);
-        
+
         self.blocks.write().insert(hash_str, block);
         *self.latest_height.write() = self.blocks.read().len() as u64 - 1;
-        
+
         Ok(())
     }
-    
+
     fn get_block(&self, hash: &[u8; 32]) -> Result<Option<Block>> {
         let hash_str = hex::encode(hash);
         Ok(self.blocks.read().get(&hash_str).cloned())
     }
-    
+
     fn get_block_by_height(&self, height: u64) -> Result<Option<Block>> {
-        Ok(self.blocks.read().values().find(|b| b.header.round_id == height).cloned())
+        Ok(self
+            .blocks
+            .read()
+            .values()
+            .find(|b| b.header.round_id == height)
+            .cloned())
     }
-    
+
     fn store_transaction(&self, tx: Transaction) -> Result<()> {
         let hash = tx.hash();
         let hash_str = hex::encode(hash);
-        
+
         self.transactions.write().insert(hash_str, tx);
         Ok(())
     }
-    
+
     fn get_transaction(&self, hash: &[u8; 32]) -> Result<Option<Transaction>> {
         let hash_str = hex::encode(hash);
         Ok(self.transactions.read().get(&hash_str).cloned())
     }
-    
+
     fn get_latest_height(&self) -> Result<u64> {
         Ok(*self.latest_height.read())
     }
-    
+
     fn get_account(&self, address: &[u8; 32]) -> Result<Option<Account>> {
         let addr_str = hex::encode(address);
         Ok(self.accounts.read().get(&addr_str).cloned())
     }
-    
+
     fn update_account(&self, account: Account) -> Result<()> {
         let addr_str = hex::encode(account.address);
         self.accounts.write().insert(addr_str, account);
         Ok(())
     }
-    
+
     fn get_all_accounts(&self) -> Result<Vec<Account>> {
         Ok(self.accounts.read().values().cloned().collect())
     }
@@ -310,7 +320,7 @@ impl Storage for MemoryStorage {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use ippan_types::{Block, Transaction};
+    use ippan_types::Block;
     use tempfile::tempdir;
 
     #[test]
@@ -318,41 +328,41 @@ mod tests {
         let temp_dir = tempdir().unwrap();
         let storage = SledStorage::new(temp_dir.path()).unwrap();
         storage.initialize().unwrap();
-        
+
         // Test storing and retrieving a block
         let block = Block::new([1u8; 32], vec![], 1, [2u8; 32]);
         let block_hash = block.hash();
-        
+
         storage.store_block(block.clone()).unwrap();
         let retrieved_block = storage.get_block(&block_hash).unwrap();
-        
+
         assert!(retrieved_block.is_some());
         assert_eq!(retrieved_block.unwrap().header.round_id, 1);
-        
+
         // Test height lookup
         let block_by_height = storage.get_block_by_height(1).unwrap();
         assert!(block_by_height.is_some());
         assert_eq!(block_by_height.unwrap().hash(), block_hash);
-        
+
         // Test latest height
         assert_eq!(storage.get_latest_height().unwrap(), 1);
     }
-    
+
     #[test]
     fn test_account_storage() {
         let temp_dir = tempdir().unwrap();
         let storage = SledStorage::new(temp_dir.path()).unwrap();
         storage.initialize().unwrap();
-        
+
         let account = Account {
             address: [1u8; 32],
             balance: 1000,
             nonce: 5,
         };
-        
+
         storage.update_account(account.clone()).unwrap();
         let retrieved = storage.get_account(&account.address).unwrap();
-        
+
         assert!(retrieved.is_some());
         assert_eq!(retrieved.unwrap().balance, 1000);
     }

--- a/crates/types/Cargo.toml
+++ b/crates/types/Cargo.toml
@@ -15,3 +15,4 @@ rand_core = { workspace = true, features = ["getrandom"] }
 time = { workspace = true }
 once_cell = { workspace = true }
 parking_lot = { workspace = true }
+ed25519-dalek = { workspace = true }

--- a/crates/types/src/block.rs
+++ b/crates/types/src/block.rs
@@ -1,6 +1,7 @@
-use serde::{Deserialize, Serialize};
-use crate::hashtimer::{HashTimer, IppanTimeMicros, random_nonce};
+use crate::hashtimer::{HashTimer, IppanTimeMicros};
 use crate::transaction::Transaction;
+use rand_core::{OsRng, RngCore};
+use serde::{Deserialize, Serialize};
 
 /// Block header containing metadata and HashTimer
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -39,19 +40,25 @@ impl Block {
         proposer_id: [u8; 32],
     ) -> Self {
         let timestamp = IppanTimeMicros::now();
-        let nonce_bytes = random_nonce();
-        let nonce = u64::from_be_bytes([
-            nonce_bytes[0], nonce_bytes[1], nonce_bytes[2], nonce_bytes[3],
-            nonce_bytes[4], nonce_bytes[5], nonce_bytes[6], nonce_bytes[7],
-        ]);
-        
+        let mut nonce_bytes = [0u8; 8];
+        OsRng.fill_bytes(&mut nonce_bytes);
+        let nonce = u64::from_be_bytes(nonce_bytes);
+
         // Compute transaction merkle root
         let tx_merkle_root = Self::compute_merkle_root(&transactions);
-        
+
         // Create HashTimer for this block
-        let payload = Self::create_payload(&prev_hash, &tx_merkle_root, round_id, &proposer_id, nonce);
-        let hashtimer = HashTimer::now_block("block", &payload, &nonce_bytes, &proposer_id);
-        
+        let payload =
+            Self::create_payload(&prev_hash, &tx_merkle_root, round_id, &proposer_id, nonce);
+        let hashtimer = HashTimer::derive(
+            "block",
+            timestamp,
+            b"block",
+            &payload,
+            &nonce_bytes,
+            &proposer_id,
+        );
+
         let header = BlockHeader {
             prev_hash,
             tx_merkle_root,
@@ -61,7 +68,7 @@ impl Block {
             hashtimer,
             timestamp,
         };
-        
+
         Self {
             header,
             transactions,
@@ -91,18 +98,18 @@ impl Block {
             // Empty block has zero merkle root
             return [0u8; 32];
         }
-        
+
         if transactions.len() == 1 {
             // Single transaction, its hash is the merkle root
             return transactions[0].hash();
         }
-        
+
         // Compute merkle tree
         let mut hashes: Vec<[u8; 32]> = transactions.iter().map(|tx| tx.hash()).collect();
-        
+
         while hashes.len() > 1 {
             let mut next_level = Vec::new();
-            
+
             for i in (0..hashes.len()).step_by(2) {
                 let left = hashes[i];
                 let right = if i + 1 < hashes.len() {
@@ -110,20 +117,20 @@ impl Block {
                 } else {
                     left // Duplicate last element if odd number
                 };
-                
+
                 let mut hasher = blake3::Hasher::new();
                 hasher.update(&left);
                 hasher.update(&right);
                 let hash = hasher.finalize();
-                
+
                 let mut combined = [0u8; 32];
                 combined.copy_from_slice(&hash.as_bytes()[0..32]);
                 next_level.push(combined);
             }
-            
+
             hashes = next_level;
         }
-        
+
         hashes[0]
     }
 
@@ -137,7 +144,7 @@ impl Block {
         hasher.update(&self.header.nonce.to_be_bytes());
         hasher.update(&self.header.hashtimer.to_hex().as_bytes());
         hasher.update(&self.header.timestamp.0.to_be_bytes());
-        
+
         let hash = hasher.finalize();
         let mut result = [0u8; 32];
         result.copy_from_slice(&hash.as_bytes()[0..32]);
@@ -151,14 +158,14 @@ impl Block {
         if computed_merkle_root != self.header.tx_merkle_root {
             return false;
         }
-        
+
         // Verify all transactions are valid
         for tx in &self.transactions {
             if !tx.is_valid() {
                 return false;
             }
         }
-        
+
         // Verify HashTimer is valid
         let payload = Self::create_payload(
             &self.header.prev_hash,
@@ -167,7 +174,7 @@ impl Block {
             &self.header.proposer_id,
             self.header.nonce,
         );
-        let _expected_hashtimer = HashTimer::derive(
+        let expected_hashtimer = HashTimer::derive(
             "block",
             self.header.timestamp,
             "block".as_bytes(),
@@ -175,12 +182,13 @@ impl Block {
             &self.header.nonce.to_be_bytes(),
             &self.header.proposer_id,
         );
-        
+
+        if expected_hashtimer != self.header.hashtimer {
+            return false;
+        }
+
         // HashTimer should be consistent (allowing for time differences)
         self.header.hashtimer.time().0 <= IppanTimeMicros::now().0
-        
-        // Note: In a real implementation, we might want to verify the exact HashTimer
-        // but for now we just check that the time is reasonable
     }
 
     /// Get block size in bytes (approximate)
@@ -205,9 +213,9 @@ mod tests {
             Transaction::new([3u8; 32], [4u8; 32], 1000, 1),
             Transaction::new([5u8; 32], [6u8; 32], 2000, 2),
         ];
-        
+
         let block = Block::new(prev_hash, transactions, round_id, proposer_id);
-        
+
         assert_eq!(block.header.prev_hash, prev_hash);
         assert_eq!(block.header.proposer_id, proposer_id);
         assert_eq!(block.header.round_id, round_id);
@@ -221,9 +229,9 @@ mod tests {
         let proposer_id = [2u8; 32];
         let round_id = 1;
         let transactions = vec![];
-        
+
         let block = Block::new(prev_hash, transactions, round_id, proposer_id);
-        
+
         assert_eq!(block.transactions.len(), 0);
         assert_eq!(block.header.tx_merkle_root, [0u8; 32]);
     }
@@ -235,9 +243,9 @@ mod tests {
         let round_id = 1;
         let tx = Transaction::new([3u8; 32], [4u8; 32], 1000, 1);
         let transactions = vec![tx.clone()];
-        
+
         let block = Block::new(prev_hash, transactions, round_id, proposer_id);
-        
+
         assert_eq!(block.transactions.len(), 1);
         assert_eq!(block.header.tx_merkle_root, tx.hash());
     }
@@ -247,7 +255,7 @@ mod tests {
         let tx1 = Transaction::new([1u8; 32], [2u8; 32], 1000, 1);
         let tx2 = Transaction::new([3u8; 32], [4u8; 32], 2000, 2);
         let transactions = vec![tx1, tx2];
-        
+
         let merkle_root = Block::compute_merkle_root(&transactions);
         assert_ne!(merkle_root, [0u8; 32]);
     }
@@ -258,10 +266,10 @@ mod tests {
         let proposer_id = [2u8; 32];
         let round_id = 1;
         let transactions = vec![Transaction::new([3u8; 32], [4u8; 32], 1000, 1)];
-        
+
         let block = Block::new(prev_hash, transactions, round_id, proposer_id);
         let hash = block.hash();
-        
+
         assert_ne!(hash, [0u8; 32]);
     }
 }

--- a/crates/types/src/lib.rs
+++ b/crates/types/src/lib.rs
@@ -1,9 +1,9 @@
+pub mod block;
 pub mod hashtimer;
 pub mod time_service;
 pub mod transaction;
-pub mod block;
 
+pub use block::*;
 pub use hashtimer::*;
 pub use time_service::*;
 pub use transaction::*;
-pub use block::*;

--- a/crates/types/src/time_service.rs
+++ b/crates/types/src/time_service.rs
@@ -1,125 +1,131 @@
 use once_cell::sync::Lazy;
 use parking_lot::RwLock;
+use std::cmp;
 use std::collections::VecDeque;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
+const DEFAULT_MAX_SAMPLES: usize = 100;
+const DEFAULT_SLEW_LIMIT_US: u64 = 1_000_000; // allow up to 1s of slewing per call
+const DEFAULT_MAX_PEER_DRIFT_US: i64 = 5 * 60 * 1_000_000; // clamp peer drift to +-5 minutes
+
 /// IPPAN Time service providing monotonic microsecond precision
 pub struct IppanTime {
-    /// Base time offset from system time
-    base_offset: Duration,
-    /// Last known time to ensure monotonicity
-    last_time: Duration,
-    /// Peer time samples for median calculation
-    peer_samples: VecDeque<Duration>,
-    /// Maximum number of peer samples to keep
+    /// Base time offset (microseconds) derived from peer consensus.
+    base_offset_us: i64,
+    /// Last emitted monotonic time in microseconds.
+    last_time_us: u64,
+    /// Peer time drift samples (microseconds).
+    peer_samples: VecDeque<i64>,
+    /// Maximum number of peer samples to keep.
     max_samples: usize,
+    /// Maximum slew applied per `now_us` call.
+    max_slew_us: u64,
+    /// Maximum absolute peer drift we accept when ingesting samples.
+    max_peer_drift_us: i64,
 }
 
 impl IppanTime {
     /// Initialize the IPPAN Time service
     pub fn init() {
-        let now = SystemTime::now()
-            .duration_since(UNIX_EPOCH)
-            .unwrap_or_default();
-        
-        *IPPAN_TIME.write() = IppanTime {
-            base_offset: Duration::ZERO,
-            last_time: now,
-            peer_samples: VecDeque::new(),
-            max_samples: 100,
-        };
+        let now_us = system_time_us();
+
+        let mut time_service = IPPAN_TIME.write();
+        time_service.base_offset_us = 0;
+        time_service.last_time_us = now_us;
+        time_service.peer_samples.clear();
     }
 
     /// Get current IPPAN time in microseconds
     pub fn now_us() -> u64 {
-        let time_service = IPPAN_TIME.read();
-        let now = SystemTime::now()
-            .duration_since(UNIX_EPOCH)
-            .unwrap_or_default();
-        
-        // Ensure monotonicity
-        let adjusted_time = if now > time_service.last_time {
-            now
-        } else {
-            time_service.last_time + Duration::from_micros(1)
-        };
+        let mut time_service = IPPAN_TIME.write();
+        let system_now_us = system_time_us();
+        let mut target = apply_offset(system_now_us, time_service.base_offset_us);
 
-        adjusted_time.as_micros() as u64
+        if time_service.last_time_us == 0 {
+            time_service.last_time_us = target;
+            return target;
+        }
+
+        if target <= time_service.last_time_us {
+            target = time_service.last_time_us.saturating_add(1);
+        } else {
+            let diff = target - time_service.last_time_us;
+            if diff > time_service.max_slew_us {
+                target = time_service
+                    .last_time_us
+                    .saturating_add(time_service.max_slew_us);
+            }
+        }
+
+        time_service.last_time_us = target;
+        target
     }
 
     /// Ingest a peer time sample for median calculation
     pub fn ingest_sample(peer_time_us: u64) {
         let mut time_service = IPPAN_TIME.write();
-        let peer_time = Duration::from_micros(peer_time_us);
-        
-        // Add sample
-        time_service.peer_samples.push_back(peer_time);
-        
-        // Keep only recent samples
+        let local_time_us = system_time_us();
+        let drift = peer_time_us as i128 - local_time_us as i128;
+        let drift = clamp_drift(drift, time_service.max_peer_drift_us);
+
+        time_service.peer_samples.push_back(drift);
+
         if time_service.peer_samples.len() > time_service.max_samples {
             time_service.peer_samples.pop_front();
         }
-        
-        // Calculate median drift and adjust base offset
+
         if time_service.peer_samples.len() >= 3 {
             let median_drift = Self::calculate_median_drift(&time_service.peer_samples);
-            time_service.base_offset = median_drift;
+            time_service.base_offset_us = median_drift;
         }
     }
 
     /// Calculate median drift from peer samples
-    fn calculate_median_drift(samples: &VecDeque<Duration>) -> Duration {
-        let mut sorted_samples: Vec<Duration> = samples.iter().cloned().collect();
-        sorted_samples.sort();
-        
+    fn calculate_median_drift(samples: &VecDeque<i64>) -> i64 {
+        let mut sorted_samples: Vec<i64> = samples.iter().copied().collect();
+        sorted_samples.sort_unstable();
+
         let median_index = sorted_samples.len() / 2;
-        let median = sorted_samples[median_index];
-        
-        // Calculate drift as difference from current system time
-        let now = SystemTime::now()
-            .duration_since(UNIX_EPOCH)
-            .unwrap_or_default();
-        
-        // Return the drift (positive means peers are ahead, negative means behind)
-        median.saturating_sub(now)
+        sorted_samples[median_index]
     }
 
     /// Get current time with peer-adjusted offset
     pub fn now_adjusted() -> Duration {
-        let time_service = IPPAN_TIME.read();
-        let now = SystemTime::now()
-            .duration_since(UNIX_EPOCH)
-            .unwrap_or_default();
-        
-        // Apply slewing towards median (never jump, only slew)
-        let target_time = now + time_service.base_offset;
-        let current_time = time_service.last_time;
-        
-        // Slew at maximum rate of 1 microsecond per microsecond (1:1 ratio)
-        let slew_rate = Duration::from_micros(1);
-        let time_diff = target_time.saturating_sub(current_time);
-        
-        if time_diff <= slew_rate {
-            target_time
-        } else {
-            current_time + slew_rate
-        }
+        Duration::from_micros(Self::now_us())
     }
+}
 
-    /// Force update the last time (used internally)
-    fn update_last_time(new_time: Duration) {
-        let mut time_service = IPPAN_TIME.write();
-        time_service.last_time = new_time;
+fn system_time_us() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_micros() as u64
+}
+
+fn apply_offset(now_us: u64, offset_us: i64) -> u64 {
+    if offset_us >= 0 {
+        now_us.saturating_add(offset_us as u64)
+    } else {
+        let abs = offset_us.checked_abs().unwrap_or(i64::MAX) as u64;
+        now_us.saturating_sub(abs)
     }
+}
+
+fn clamp_drift(drift: i128, limit: i64) -> i64 {
+    let limit = limit as i128;
+    cmp::min(cmp::max(drift, -limit), limit) as i64
 }
 
 /// Global IPPAN Time instance
 static IPPAN_TIME: Lazy<RwLock<IppanTime>> = Lazy::new(|| {
+    let now_us = system_time_us();
     RwLock::new(IppanTime {
-        base_offset: Duration::ZERO,
-        last_time: Duration::ZERO,
+        base_offset_us: 0,
+        last_time_us: now_us,
         peer_samples: VecDeque::new(),
-        max_samples: 100,
+        max_samples: DEFAULT_MAX_SAMPLES,
+        max_slew_us: DEFAULT_SLEW_LIMIT_US,
+        max_peer_drift_us: DEFAULT_MAX_PEER_DRIFT_US,
     })
 });
 
@@ -146,11 +152,11 @@ mod tests {
     #[test]
     fn test_monotonic_time() {
         ippan_time_init();
-        
+
         let time1 = ippan_time_now();
         thread::sleep(Duration::from_millis(1));
         let time2 = ippan_time_now();
-        
+
         // Time should be monotonically increasing
         assert!(time2 > time1);
     }
@@ -158,19 +164,20 @@ mod tests {
     #[test]
     fn test_peer_sample_ingestion() {
         ippan_time_init();
-        
-        // Ingest some peer samples
-        let peer_times = vec![
-            1000000, // 1 second
-            1000001, // 1 second + 1 microsecond
-            1000002, // 1 second + 2 microseconds
-        ];
-        
+
+        // Use samples close to local time to simulate honest peers
+        let base_time = ippan_time_now();
+        let peer_times = vec![base_time + 500, base_time + 1_000, base_time + 750];
+
         for peer_time in peer_times {
             ippan_time_ingest_sample(peer_time);
         }
-        
-        // Should not panic and should handle samples correctly
+
+        // Base offset should track the peer median (positive drift)
+        let service = super::IPPAN_TIME.read();
+        assert!(service.base_offset_us > 0);
+        drop(service);
+
         let current_time = ippan_time_now();
         assert!(current_time > 0);
     }
@@ -178,12 +185,27 @@ mod tests {
     #[test]
     fn test_time_precision() {
         ippan_time_init();
-        
+
         let time1 = ippan_time_now();
         let time2 = ippan_time_now();
-        
-        // Should have microsecond precision
+
+        // Should have microsecond precision with enforced monotonicity
         let diff = time2.saturating_sub(time1);
-        assert!(diff <= 1); // Should be 0 or 1 microsecond difference
+        assert!(diff <= 1_000);
+    }
+
+    #[test]
+    fn test_negative_peer_drift() {
+        ippan_time_init();
+
+        let base_time = ippan_time_now();
+        let earlier_peer = base_time.saturating_sub(1_500);
+
+        ippan_time_ingest_sample(earlier_peer);
+        ippan_time_ingest_sample(earlier_peer.saturating_sub(250));
+        ippan_time_ingest_sample(earlier_peer.saturating_sub(500));
+
+        let service = super::IPPAN_TIME.read();
+        assert!(service.base_offset_us <= -1_000);
     }
 }

--- a/node/src/main.rs
+++ b/node/src/main.rs
@@ -1,17 +1,15 @@
 use anyhow::Result;
 use clap::{Arg, Command};
 use config::Config;
-use ippan_consensus::{PoAConsensus, PoAConfig, Validator};
+use ippan_consensus::{PoAConfig, PoAConsensus, Validator};
 use ippan_p2p::{HttpP2PNetwork, P2PConfig};
-use ippan_rpc::{AppState, start_server};
-use ippan_storage::{SledStorage, Storage};
-use ippan_types::{ippan_time_init, ippan_time_now, HashTimer, IppanTimeMicros, Transaction};
-use std::path::Path;
-use std::sync::Arc;
+use ippan_rpc::{start_server, AppState};
+use ippan_storage::SledStorage;
+use ippan_types::{ippan_time_init, ippan_time_now, HashTimer, IppanTimeMicros};
 use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::Arc;
 use std::time::Instant;
-use tokio::sync::mpsc;
-use tracing::{info, warn, error};
+use tracing::{error, info};
 use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt, EnvFilter};
 
 /// Application configuration
@@ -20,30 +18,30 @@ struct AppConfig {
     // Node identity
     node_id: String,
     validator_id: [u8; 32],
-    
+
     // Network
     rpc_host: String,
     rpc_port: u16,
     p2p_host: String,
     p2p_port: u16,
-    
+
     // Storage
     data_dir: String,
     db_path: String,
-    
+
     // Consensus
     slot_duration_ms: u64,
     max_transactions_per_block: usize,
     block_reward: u64,
-    
+
     // P2P
     bootstrap_nodes: Vec<String>,
     max_peers: usize,
-    
+
     // Logging
     log_level: String,
     log_format: String,
-    
+
     // Development
     dev_mode: bool,
 }
@@ -54,11 +52,12 @@ impl AppConfig {
         let config = Config::builder()
             .add_source(config::Environment::with_prefix("IPPAN"))
             .build()?;
-        
+
         // Parse validator ID from hex string
-        let validator_id_str = config.get_string("VALIDATOR_ID")
-            .unwrap_or_else(|_| "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef".to_string());
-        
+        let validator_id_str = config.get_string("VALIDATOR_ID").unwrap_or_else(|_| {
+            "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef".to_string()
+        });
+
         let validator_id = if validator_id_str.len() == 64 {
             let mut id = [0u8; 32];
             hex::decode_to_slice(&validator_id_str, &mut id)?;
@@ -74,24 +73,65 @@ impl AppConfig {
             }
             id
         };
-        
+
         Ok(Self {
-            node_id: config.get_string("NODE_ID").unwrap_or_else(|_| "ippan_node".to_string()),
+            node_id: config
+                .get_string("NODE_ID")
+                .unwrap_or_else(|_| "ippan_node".to_string()),
             validator_id,
-            rpc_host: config.get_string("RPC_HOST").unwrap_or_else(|_| "0.0.0.0".to_string()),
-            rpc_port: config.get_string("RPC_PORT").unwrap_or_else(|_| "8080".to_string()).parse()?,
-            p2p_host: config.get_string("P2P_HOST").unwrap_or_else(|_| "0.0.0.0".to_string()),
-            p2p_port: config.get_string("P2P_PORT").unwrap_or_else(|_| "9000".to_string()).parse()?,
-            data_dir: config.get_string("DATA_DIR").unwrap_or_else(|_| "./data".to_string()),
-            db_path: config.get_string("DB_PATH").unwrap_or_else(|_| "./data/db".to_string()),
-            slot_duration_ms: config.get_string("SLOT_DURATION_MS").unwrap_or_else(|_| "1000".to_string()).parse()?,
-            max_transactions_per_block: config.get_string("MAX_TRANSACTIONS_PER_BLOCK").unwrap_or_else(|_| "1000".to_string()).parse()?,
-            block_reward: config.get_string("BLOCK_REWARD").unwrap_or_else(|_| "10".to_string()).parse()?,
-            bootstrap_nodes: config.get_string("BOOTSTRAP_NODES").unwrap_or_default().split(',').map(|s| s.trim().to_string()).filter(|s| !s.is_empty()).collect(),
-            max_peers: config.get_string("MAX_PEERS").unwrap_or_else(|_| "50".to_string()).parse()?,
-            log_level: config.get_string("LOG_LEVEL").unwrap_or_else(|_| "info".to_string()),
-            log_format: config.get_string("LOG_FORMAT").unwrap_or_else(|_| "pretty".to_string()),
-            dev_mode: config.get_string("DEV_MODE").unwrap_or_else(|_| "false".to_string()).parse()?,
+            rpc_host: config
+                .get_string("RPC_HOST")
+                .unwrap_or_else(|_| "0.0.0.0".to_string()),
+            rpc_port: config
+                .get_string("RPC_PORT")
+                .unwrap_or_else(|_| "8080".to_string())
+                .parse()?,
+            p2p_host: config
+                .get_string("P2P_HOST")
+                .unwrap_or_else(|_| "0.0.0.0".to_string()),
+            p2p_port: config
+                .get_string("P2P_PORT")
+                .unwrap_or_else(|_| "9000".to_string())
+                .parse()?,
+            data_dir: config
+                .get_string("DATA_DIR")
+                .unwrap_or_else(|_| "./data".to_string()),
+            db_path: config
+                .get_string("DB_PATH")
+                .unwrap_or_else(|_| "./data/db".to_string()),
+            slot_duration_ms: config
+                .get_string("SLOT_DURATION_MS")
+                .unwrap_or_else(|_| "1000".to_string())
+                .parse()?,
+            max_transactions_per_block: config
+                .get_string("MAX_TRANSACTIONS_PER_BLOCK")
+                .unwrap_or_else(|_| "1000".to_string())
+                .parse()?,
+            block_reward: config
+                .get_string("BLOCK_REWARD")
+                .unwrap_or_else(|_| "10".to_string())
+                .parse()?,
+            bootstrap_nodes: config
+                .get_string("BOOTSTRAP_NODES")
+                .unwrap_or_default()
+                .split(',')
+                .map(|s| s.trim().to_string())
+                .filter(|s| !s.is_empty())
+                .collect(),
+            max_peers: config
+                .get_string("MAX_PEERS")
+                .unwrap_or_else(|_| "50".to_string())
+                .parse()?,
+            log_level: config
+                .get_string("LOG_LEVEL")
+                .unwrap_or_else(|_| "info".to_string()),
+            log_format: config
+                .get_string("LOG_FORMAT")
+                .unwrap_or_else(|_| "pretty".to_string()),
+            dev_mode: config
+                .get_string("DEV_MODE")
+                .unwrap_or_else(|_| "false".to_string())
+                .parse()?,
         })
     }
 }
@@ -102,56 +142,58 @@ async fn main() -> Result<()> {
     let matches = Command::new("ippan-node")
         .version(env!("CARGO_PKG_VERSION"))
         .about("IPPAN Blockchain Node")
-        .arg(Arg::new("config")
-            .short('c')
-            .long("config")
-            .value_name("FILE")
-            .help("Configuration file path"))
-        .arg(Arg::new("data-dir")
-            .short('d')
-            .long("data-dir")
-            .value_name("DIR")
-            .help("Data directory"))
-        .arg(Arg::new("dev")
-            .long("dev")
-            .help("Run in development mode"))
+        .arg(
+            Arg::new("config")
+                .short('c')
+                .long("config")
+                .value_name("FILE")
+                .help("Configuration file path"),
+        )
+        .arg(
+            Arg::new("data-dir")
+                .short('d')
+                .long("data-dir")
+                .value_name("DIR")
+                .help("Data directory"),
+        )
+        .arg(Arg::new("dev").long("dev").help("Run in development mode"))
         .get_matches();
-    
+
     // Load configuration
     let mut config = AppConfig::load()?;
-    
+
     // Override with command line arguments
     if let Some(data_dir) = matches.get_one::<String>("data-dir") {
         config.data_dir = data_dir.clone();
         config.db_path = format!("{}/db", data_dir);
     }
-    
+
     if matches.get_flag("dev") {
         config.dev_mode = true;
         config.log_level = "debug".to_string();
         config.log_format = "pretty".to_string();
     }
-    
+
     // Initialize logging
     init_logging(&config)?;
-    
+
     // Initialize IPPAN Time service
     ippan_time_init();
     info!("IPPAN Time service initialized");
-    
+
     info!("Starting IPPAN node: {}", config.node_id);
     info!("Validator ID: {}", hex::encode(config.validator_id));
     info!("Data directory: {}", config.data_dir);
     info!("Development mode: {}", config.dev_mode);
-    
+
     // Create data directory
     std::fs::create_dir_all(&config.data_dir)?;
-    
+
     // Initialize storage
     let storage = Arc::new(SledStorage::new(&config.db_path)?);
     storage.initialize()?;
     info!("Storage initialized at {}", config.db_path);
-    
+
     // Initialize consensus
     let consensus_config = PoAConfig {
         slot_duration_ms: config.slot_duration_ms,
@@ -164,11 +206,11 @@ async fn main() -> Result<()> {
         max_transactions_per_block: config.max_transactions_per_block,
         block_reward: config.block_reward,
     };
-    
+
     let mut consensus = PoAConsensus::new(consensus_config, storage.clone(), config.validator_id);
     consensus.start().await?;
     info!("Consensus engine started");
-    
+
     // Initialize P2P network
     let p2p_config = P2PConfig {
         listen_address: format!("http://{}:{}", config.p2p_host, config.p2p_port),
@@ -178,22 +220,25 @@ async fn main() -> Result<()> {
         message_timeout: std::time::Duration::from_secs(10),
         retry_attempts: 3,
     };
-    
+
     let local_p2p_address = format!("http://{}:{}", config.p2p_host, config.p2p_port);
     let mut p2p_network = HttpP2PNetwork::new(p2p_config, local_p2p_address)?;
     p2p_network.start().await?;
-    info!("HTTP P2P network started on {}:{}", config.p2p_host, config.p2p_port);
-    
+    info!(
+        "HTTP P2P network started on {}:{}",
+        config.p2p_host, config.p2p_port
+    );
+
     // Get peer ID before moving p2p_network
     let peer_id = p2p_network.get_local_peer_id();
-    
+
     // Create transaction channel for consensus
     let tx_sender = consensus.get_tx_sender();
-    
+
     // Initialize RPC server
     let peer_count = Arc::new(AtomicUsize::new(0));
     let start_time = Instant::now();
-    
+
     let p2p_network_arc = Arc::new(p2p_network);
     let p2p_network_for_shutdown = p2p_network_arc.clone();
     let app_state = AppState {
@@ -201,26 +246,27 @@ async fn main() -> Result<()> {
         start_time,
         peer_count: peer_count.clone(),
         p2p_network: Some(p2p_network_arc.clone()),
+        tx_sender: Some(tx_sender.clone()),
     };
-    
+
     let rpc_addr = format!("{}:{}", config.rpc_host, config.rpc_port);
     let rpc_addr_clone = rpc_addr.clone();
     info!("Starting RPC server on {}", rpc_addr);
-    
+
     // Start RPC server in background
     let rpc_handle = tokio::spawn(async move {
         if let Err(e) = start_server(app_state, &rpc_addr_clone).await {
             error!("RPC server error: {}", e);
         }
     });
-    
-    // Create a boot HashTimer to demonstrate the system
+
+    // Create a boot HashTimer to uniquely identify this startup
     let current_time = IppanTimeMicros(ippan_time_now());
     let domain = "boot";
     let payload = b"node_startup";
     let nonce = ippan_types::random_nonce();
     let node_id = config.node_id.as_bytes();
-    
+
     let boot_hashtimer = HashTimer::derive(
         domain,
         current_time,
@@ -229,69 +275,61 @@ async fn main() -> Result<()> {
         &nonce,
         node_id,
     );
-    
+
     info!("Boot HashTimer: {}", boot_hashtimer.to_hex());
     info!("Current IPPAN Time: {} microseconds", current_time.0);
-    
-    // Demonstrate HashTimer creation for different contexts
-    let tx_hashtimer = HashTimer::now_tx("demo_tx", b"transfer_100_tokens", &nonce, node_id);
-    let block_hashtimer = HashTimer::now_block("demo_block", b"block_creation", &nonce, node_id);
-    let round_hashtimer = HashTimer::now_round("demo_round", b"consensus_round", &nonce, node_id);
-    
-    info!("Transaction HashTimer: {}", tx_hashtimer.to_hex());
-    info!("Block HashTimer: {}", block_hashtimer.to_hex());
-    info!("Round HashTimer: {}", round_hashtimer.to_hex());
-    
-    // Demonstrate time monotonicity
-    info!("Testing time monotonicity...");
-    for i in 0..5 {
-        let time1 = ippan_time_now();
-        tokio::time::sleep(tokio::time::Duration::from_millis(1)).await;
-        let time2 = ippan_time_now();
-        info!("Time check {}: {} -> {} (diff: {})", i, time1, time2, time2 - time1);
-    }
-    
+
+    let consensus_state = consensus.get_state();
+    info!(
+        "Consensus state => slot: {}, latest height: {}, proposer: {:?}",
+        consensus_state.current_slot,
+        consensus_state.latest_block_height,
+        consensus_state.current_proposer.map(hex::encode)
+    );
+
     // Update peer count periodically
     let peer_count_updater = {
         let peer_count = peer_count.clone();
+        let network = p2p_network_arc.clone();
         tokio::spawn(async move {
             let mut interval = tokio::time::interval(tokio::time::Duration::from_secs(10));
             loop {
                 interval.tick().await;
-                // Simulate peer count for now
-                peer_count.store(0, Ordering::Relaxed);
+                let count = network.get_peer_count();
+                peer_count.store(count, Ordering::Relaxed);
             }
         })
     };
-    
+
     info!("IPPAN node is ready and running");
     info!("RPC API available at: http://{}", rpc_addr);
-    info!("P2P network listening on: {}:{}", config.p2p_host, config.p2p_port);
+    info!(
+        "P2P network listening on: {}:{}",
+        config.p2p_host, config.p2p_port
+    );
     info!("Node ID: {}", peer_id);
-    
+
     // Keep the node running
     tokio::signal::ctrl_c().await?;
     info!("Shutting down IPPAN node");
-    
+
     // Stop components gracefully
     consensus.stop().await?;
-    // Note: We can't call stop() on the Arc-wrapped network
-    // In a real implementation, we'd need a different approach
-    info!("P2P network shutdown requested");
+    p2p_network_for_shutdown.stop().await?;
     rpc_handle.abort();
     peer_count_updater.abort();
-    
+
     // Flush storage
     storage.flush()?;
-    
+
     info!("IPPAN node shutdown complete");
     Ok(())
 }
 
 fn init_logging(config: &AppConfig) -> Result<()> {
-    let filter = EnvFilter::try_from_default_env()
-        .unwrap_or_else(|_| EnvFilter::new(&config.log_level));
-    
+    let filter =
+        EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new(&config.log_level));
+
     if config.log_format == "json" {
         tracing_subscriber::registry()
             .with(filter)
@@ -303,6 +341,6 @@ fn init_logging(config: &AppConfig) -> Result<()> {
             .with(tracing_subscriber::fmt::layer().pretty())
             .init();
     }
-    
+
     Ok(())
 }


### PR DESCRIPTION
## Summary
- integrate the RPC transaction submission flow with consensus forwarding, peer broadcasts, and expanded coverage tests
- preserve the node wiring for PoA consensus, storage, and HTTP P2P while cleaning up unused handles and peer discovery helpers
- adopt the refined IPPAN time service and HashTimer implementation with monotonic slewing and drift handling

## Testing
- `cargo test --workspace`


------
https://chatgpt.com/codex/tasks/task_e_68d26b424f78832bbd62168acba75f19