### PR TITLE
Fix CI integration-tests feature and clippy warnings

### DIFF
--- a/crates/consensus/Cargo.toml
+++ b/crates/consensus/Cargo.toml
@@ -5,6 +5,9 @@ edition.workspace = true
 license.workspace = true
 authors.workspace = true
 
+[features]
+integration-tests = []
+
 [dependencies]
 ippan-types = { path = "../types" }
 ippan-storage = { path = "../storage" }

--- a/crates/consensus/src/lib.rs
+++ b/crates/consensus/src/lib.rs
@@ -189,7 +189,7 @@ impl PoAConsensus {
     pub fn get_state(&self) -> ConsensusState {
         let current_slot = *self.current_slot.read();
         let proposer = Self::get_proposer_for_slot(&self.config.validators, current_slot);
-        let is_proposing = proposer.map_or(false, |p| p == self.validator_id);
+        let is_proposing = proposer == Some(self.validator_id);
 
         ConsensusState {
             current_slot,
@@ -387,6 +387,7 @@ impl PoAConsensus {
 }
 
 /// Legacy consensus engine trait for compatibility
+#[allow(async_fn_in_trait)]
 pub trait ConsensusEngine {
     async fn start(&mut self) -> Result<()>;
     async fn stop(&mut self) -> Result<()>;

--- a/crates/crypto/Cargo.toml
+++ b/crates/crypto/Cargo.toml
@@ -5,6 +5,9 @@ edition.workspace = true
 license.workspace = true
 authors.workspace = true
 
+[features]
+integration-tests = []
+
 [dependencies]
 ippan-types = { path = "../types" }
 anyhow = { workspace = true }

--- a/crates/crypto/src/lib.rs
+++ b/crates/crypto/src/lib.rs
@@ -15,7 +15,7 @@ impl KeyPair {
         let mut rng = OsRng;
         let mut secret_key = [0u8; 32];
         rng.fill_bytes(&mut secret_key);
-        let signing_key = SigningKey::from_bytes(&secret_key.into());
+        let signing_key = SigningKey::from_bytes(&secret_key);
         let verifying_key = signing_key.verifying_key();
 
         Self {

--- a/crates/mempool/Cargo.toml
+++ b/crates/mempool/Cargo.toml
@@ -5,6 +5,9 @@ edition.workspace = true
 license.workspace = true
 authors.workspace = true
 
+[features]
+integration-tests = []
+
 [dependencies]
 ippan-types = { path = "../types" }
 anyhow = { workspace = true }

--- a/crates/mempool/src/lib.rs
+++ b/crates/mempool/src/lib.rs
@@ -46,7 +46,7 @@ impl Mempool {
         // Update sender nonce index
         sender_nonces
             .entry(sender)
-            .or_insert_with(BTreeMap::new)
+            .or_default()
             .insert(tx.nonce, tx_hash);
 
         Ok(true)

--- a/crates/p2p/Cargo.toml
+++ b/crates/p2p/Cargo.toml
@@ -5,6 +5,9 @@ edition.workspace = true
 license.workspace = true
 authors.workspace = true
 
+[features]
+integration-tests = []
+
 [dependencies]
 ippan-types = { path = "../types" }
 anyhow = { workspace = true }

--- a/crates/rpc/Cargo.toml
+++ b/crates/rpc/Cargo.toml
@@ -5,6 +5,9 @@ edition.workspace = true
 license.workspace = true
 authors.workspace = true
 
+[features]
+integration-tests = []
+
 [dependencies]
 ippan-types = { path = "../types" }
 ippan-storage = { path = "../storage" }

--- a/crates/storage/Cargo.toml
+++ b/crates/storage/Cargo.toml
@@ -5,6 +5,9 @@ edition.workspace = true
 license.workspace = true
 authors.workspace = true
 
+[features]
+integration-tests = []
+
 [dependencies]
 ippan-types = { path = "../types" }
 anyhow = { workspace = true }

--- a/crates/storage/src/lib.rs
+++ b/crates/storage/src/lib.rs
@@ -283,6 +283,12 @@ impl MemoryStorage {
     }
 }
 
+impl Default for MemoryStorage {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl Storage for MemoryStorage {
     fn store_block(&self, block: Block) -> Result<()> {
         let hash = block.hash();
@@ -358,7 +364,7 @@ impl Storage for MemoryStorage {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use ippan_types::{Block, Transaction};
+    use ippan_types::Block;
     use tempfile::tempdir;
 
     #[test]

--- a/crates/types/Cargo.toml
+++ b/crates/types/Cargo.toml
@@ -5,6 +5,9 @@ edition.workspace = true
 license.workspace = true
 authors.workspace = true
 
+[features]
+integration-tests = []
+
 [dependencies]
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/crates/types/src/block.rs
+++ b/crates/types/src/block.rs
@@ -64,7 +64,7 @@ impl Block {
             tx_merkle_root,
             round_id,
             proposer_id,
-            nonce: nonce,
+            nonce,
             hashtimer,
             timestamp,
         };
@@ -142,7 +142,7 @@ impl Block {
         hasher.update(&self.header.round_id.to_be_bytes());
         hasher.update(&self.header.proposer_id);
         hasher.update(&self.header.nonce.to_be_bytes());
-        hasher.update(&self.header.hashtimer.to_hex().as_bytes());
+        hasher.update(self.header.hashtimer.to_hex().as_bytes());
         hasher.update(&self.header.timestamp.0.to_be_bytes());
 
         let hash = hasher.finalize();

--- a/crates/types/src/time_service.rs
+++ b/crates/types/src/time_service.rs
@@ -32,7 +32,7 @@ impl IppanTime {
 
     /// Get current IPPAN time in microseconds
     pub fn now_us() -> u64 {
-        let time_service = IPPAN_TIME.read();
+        let mut time_service = IPPAN_TIME.write();
         let now = SystemTime::now()
             .duration_since(UNIX_EPOCH)
             .unwrap_or_default();
@@ -43,6 +43,8 @@ impl IppanTime {
         } else {
             time_service.last_time + Duration::from_micros(1)
         };
+
+        time_service.last_time = adjusted_time;
 
         adjusted_time.as_micros() as u64
     }
@@ -104,12 +106,6 @@ impl IppanTime {
         } else {
             current_time + slew_rate
         }
-    }
-
-    /// Force update the last time (used internally)
-    fn update_last_time(new_time: Duration) {
-        let mut time_service = IPPAN_TIME.write();
-        time_service.last_time = new_time;
     }
 }
 

--- a/crates/types/src/transaction.rs
+++ b/crates/types/src/transaction.rs
@@ -71,7 +71,7 @@ impl Transaction {
         hasher.update(&self.to);
         hasher.update(&self.amount.to_be_bytes());
         hasher.update(&self.nonce.to_be_bytes());
-        hasher.update(&self.hashtimer.to_hex().as_bytes());
+        hasher.update(self.hashtimer.to_hex().as_bytes());
         // The placeholder implementation doesn't perform real cryptographic signing.
         // Keep the parameter to maintain API compatibility but avoid using it so that
         // verification can deterministically recompute the same signature from the
@@ -95,7 +95,7 @@ impl Transaction {
         hasher.update(&self.to);
         hasher.update(&self.amount.to_be_bytes());
         hasher.update(&self.nonce.to_be_bytes());
-        hasher.update(&self.hashtimer.to_hex().as_bytes());
+        hasher.update(self.hashtimer.to_hex().as_bytes());
 
         let mut expected_signature = [0u8; 64];
         hasher.finalize_xof().fill(&mut expected_signature);
@@ -115,7 +115,7 @@ impl Transaction {
         hasher.update(&self.amount.to_be_bytes());
         hasher.update(&self.nonce.to_be_bytes());
         hasher.update(&self.signature);
-        hasher.update(&self.hashtimer.to_hex().as_bytes());
+        hasher.update(self.hashtimer.to_hex().as_bytes());
 
         let hash = hasher.finalize();
         let mut result = [0u8; 32];

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -5,6 +5,9 @@ edition.workspace = true
 license.workspace = true
 authors.workspace = true
 
+[features]
+integration-tests = []
+
 [[bin]]
 name = "ippan-node"
 path = "src/main.rs"


### PR DESCRIPTION
## Summary
- add a no-op `integration-tests` feature to each workspace crate so the CI cargo invocation succeeds
- update the time service to persist the last timestamp and give `MemoryStorage` a `Default` impl for cleaner tests
- clean up clippy warnings across consensus, crypto, mempool, and block/transaction hashing code

## Testing
- cargo fmt
- cargo clippy --all-targets --all-features -- -D warnings
- cargo test --all
- cargo test --all --features integration-tests

------
https://chatgpt.com/codex/tasks/task_e_68d36de53a70832bbf39a5e8ee94e564