### PR TITLE
Add NAT-aware P2P networking and streamline RPC

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1290,7 +1290,7 @@ dependencies = [
  "ippan-p2p",
  "ippan-storage",
  "ippan-types",
- "parking_lot 0.12.4",
+ "rand_core",
  "serde",
  "serde_json",
  "thiserror 1.0.69",
@@ -1329,7 +1329,6 @@ dependencies = [
  "serde",
  "serde_bytes",
  "serde_json",
- "thiserror 1.0.69",
  "time",
 ]
 

--- a/README.md
+++ b/README.md
@@ -143,6 +143,9 @@ Environment variables:
 - `RUST_LOG`: Logging level (default: info)
 - `IPPAN_NETWORK`: Network type (mainnet/testnet)
 - `IPPAN_DATA_DIR`: Data directory path
+- `P2P_PUBLIC_HOST`: Optional public hostname or URL to advertise to peers when running behind proxies or load balancers.
+- `P2P_ENABLE_UPNP`: Set to `true` to attempt automatic UPnP/NAT-PMP port forwarding for home routers.
+- `P2P_EXTERNAL_IP_SERVICES`: Comma-separated list of services used to discover the external IP address when no static host is configured (defaults to `https://api.ipify.org,https://ifconfig.me/ip`).
 
 ## 📈 Performance
 

--- a/crates/rpc/Cargo.toml
+++ b/crates/rpc/Cargo.toml
@@ -27,3 +27,4 @@ futures = { workspace = true }
 
 [dev-dependencies]
 ed25519-dalek = { workspace = true }
+rand_core = { workspace = true }


### PR DESCRIPTION
## Summary
- overhaul the HTTP P2P layer to auto-detect public addresses, support optional UPnP port mapping, and continually announce peers
- simplify the RPC service to expose production-ready endpoints and integrate with the updated P2P network
- clean up transaction hashing/signature logic and extend node configuration plus documentation for new deployment settings

## Testing
- cargo test

------
https://chatgpt.com/codex/tasks/task_e_68d41e456ba4832b823f4a02742ad7a0