### PR TITLE
feat: add expo mobile client for unified UI

### DIFF
--- a/apps/mobile/.eslintrc.js
+++ b/apps/mobile/.eslintrc.js
@@ -1,0 +1,31 @@
+module.exports = {
+  root: true,
+  env: {
+    browser: true,
+    es2021: true
+  },
+  parser: '@typescript-eslint/parser',
+  parserOptions: {
+    ecmaVersion: 2020,
+    sourceType: 'module',
+    ecmaFeatures: {
+      jsx: true
+    }
+  },
+  plugins: ['@typescript-eslint', 'react', 'react-hooks'],
+  extends: [
+    'eslint:recommended',
+    'plugin:@typescript-eslint/recommended',
+    'plugin:react/recommended',
+    'plugin:react-hooks/recommended'
+  ],
+  settings: {
+    react: {
+      version: 'detect'
+    }
+  },
+  rules: {
+    '@typescript-eslint/no-unused-vars': ['warn', { argsIgnorePattern: '^_', varsIgnorePattern: '^_' }],
+    'react/react-in-jsx-scope': 'off'
+  }
+};

--- a/apps/mobile/App.tsx
+++ b/apps/mobile/App.tsx
@@ -1,0 +1,89 @@
+import 'react-native-gesture-handler';
+import React from 'react';
+import { NavigationContainer, DefaultTheme, Theme } from '@react-navigation/native';
+import { createBottomTabNavigator } from '@react-navigation/bottom-tabs';
+import { SafeAreaProvider } from 'react-native-safe-area-context';
+import { StatusBar } from 'expo-status-bar';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { Ionicons } from '@expo/vector-icons';
+
+import WalletOverviewScreen from './src/screens/wallet/WalletOverviewScreen';
+import ExplorerScreen from './src/screens/explorer/ExplorerScreen';
+import NeuralScreen from './src/screens/neural/NeuralScreen';
+import NodeManagementScreen from './src/screens/nodes/NodeManagementScreen';
+import { ApiProvider } from './src/providers/ApiProvider';
+import { WalletProvider } from './src/providers/WalletProvider';
+
+const Tab = createBottomTabNavigator();
+
+const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: {
+      staleTime: 60 * 1000,
+      refetchOnWindowFocus: false
+    }
+  }
+});
+
+const navigationTheme: Theme = {
+  ...DefaultTheme,
+  colors: {
+    ...DefaultTheme.colors,
+    background: '#0f172a',
+    card: '#111c33',
+    text: '#f8fafc',
+    border: '#1f2a44',
+    notification: '#38bdf8',
+    primary: '#38bdf8'
+  }
+};
+
+export default function App() {
+  return (
+    <SafeAreaProvider>
+      <ApiProvider>
+        <WalletProvider>
+          <QueryClientProvider client={queryClient}>
+            <NavigationContainer theme={navigationTheme}>
+              <StatusBar style="light" />
+              <Tab.Navigator
+                screenOptions={({ route }) => ({
+                  headerShown: false,
+                  tabBarStyle: {
+                    backgroundColor: '#111c33',
+                    borderTopColor: '#1f2a44',
+                    paddingBottom: 6,
+                    paddingTop: 6,
+                    height: 64
+                  },
+                  tabBarActiveTintColor: '#38bdf8',
+                  tabBarInactiveTintColor: '#94a3b8',
+                  tabBarIcon: ({ color, size }) => {
+                    let iconName: keyof typeof Ionicons.glyphMap = 'apps';
+
+                    if (route.name === 'Wallet') {
+                      iconName = 'wallet-outline';
+                    } else if (route.name === 'Explorer') {
+                      iconName = 'planet-outline';
+                    } else if (route.name === 'Neural') {
+                      iconName = 'hardware-chip-outline';
+                    } else if (route.name === 'Nodes') {
+                      iconName = 'settings-outline';
+                    }
+
+                    return <Ionicons name={iconName} size={size} color={color} />;
+                  }
+                })}
+              >
+                <Tab.Screen name="Wallet" component={WalletOverviewScreen} />
+                <Tab.Screen name="Explorer" component={ExplorerScreen} />
+                <Tab.Screen name="Neural" component={NeuralScreen} />
+                <Tab.Screen name="Nodes" component={NodeManagementScreen} />
+              </Tab.Navigator>
+            </NavigationContainer>
+          </QueryClientProvider>
+        </WalletProvider>
+      </ApiProvider>
+    </SafeAreaProvider>
+  );
+}

--- a/apps/mobile/README.md
+++ b/apps/mobile/README.md
@@ -1,1 +1,79 @@
-stub
+# IPPAN Unified Mobile
+
+The mobile companion to the [Unified UI](../unified-ui) delivers wallet, explorer, neural-network and node-management tooling on Android and iOS. It is built with Expo + React Native so that a single codebase targets both platforms while sharing the same API contracts as the web dashboard.
+
+## Features
+
+- **Wallet & Finance** – connect a watch-only wallet or generate a local demo wallet, review balances, submit signed transactions, track domains, storage metrics and registry activity.
+- **Blockchain Explorer** – monitor node telemetry, peer connectivity, mempool pressure, consensus health and recent block production.
+- **Neural Marketplace** – browse IPPAN models and datasets, inspect inference workloads, bids and proof events. Live API responses are used when available with graceful fallbacks for offline demos.
+- **Node Management** – switch between validators/gateways, run health checks and pick pre-configured endpoints without leaving the app.
+
+## Getting started
+
+The project lives under `apps/mobile` and uses Expo for development convenience.
+
+```bash
+cd apps/mobile
+npm install
+```
+
+### Development
+
+- **Start the bundler** – `npm start`
+- **Run on Android** – `npm run android`
+- **Run on iOS** – `npm run ios`
+
+The Expo CLI will guide you through connecting a simulator or physical device. Make sure your machine meets the [Expo tooling prerequisites](https://docs.expo.dev/get-started/installation/).
+
+### Environment configuration
+
+The app reads the active API endpoint from `app.json` (`extra.defaultApiBaseUrl`). You can override it at runtime from the **Nodes** tab:
+
+1. Open the **Nodes** tab.
+2. Enter the base URL of the validator or gateway (for example `http://localhost:8080`).
+3. Press **Apply** or choose one of the curated endpoints.
+
+The selection persists in `AsyncStorage`, mirroring the behaviour of the web UI.
+
+### Shared behaviour with the web client
+
+- Wallet and node state are persisted across restarts just like the `localStorage` strategy in `apps/unified-ui`.
+- API helpers (`fetchWalletBalance`, `fetchNodeStatus`, …) mimic the TypeScript contracts used on the web and gracefully down-level to empty data when a node does not expose a specific endpoint.
+- Mock/fallback data mirrors the content shown in the desktop experience when real endpoints are unavailable.
+
+### Linting & type checking
+
+```bash
+npm run lint
+npm run typecheck
+```
+
+Both commands are recommended before committing changes.
+
+## Project structure
+
+```
+apps/mobile
+├── App.tsx                # Entry point with navigation + providers
+├── app.json               # Expo configuration (name, slug, default API URL)
+├── src/
+│   ├── api/               # Axios-powered API clients shared across screens
+│   ├── components/        # Reusable UI primitives (Card, Button, etc.)
+│   ├── data/              # Mock data used when endpoints are offline
+│   ├── providers/         # API + Wallet context providers (AsyncStorage backed)
+│   ├── screens/           # Wallet, Explorer, Neural and Nodes tabs
+│   └── utils/             # Formatting helpers
+└── README.md
+```
+
+## Production builds
+
+Once the Expo project is configured with an EAS account you can produce native binaries with:
+
+```bash
+npx expo run:android --variant release
+npx expo run:ios --configuration Release
+```
+
+Refer to the [Expo build documentation](https://docs.expo.dev/build/introduction/) for signing and store submission guidance.

--- a/apps/mobile/app.json
+++ b/apps/mobile/app.json
@@ -1,0 +1,22 @@
+{
+  "expo": {
+    "name": "IPPAN Unified Mobile",
+    "slug": "ippan-mobile",
+    "version": "1.0.0",
+    "orientation": "portrait",
+    "userInterfaceStyle": "automatic",
+    "splash": {
+      "backgroundColor": "#0f172a"
+    },
+    "assetBundlePatterns": ["**/*"],
+    "ios": {
+      "supportsTablet": true
+    },
+    "android": {
+      "permissions": []
+    },
+    "extra": {
+      "defaultApiBaseUrl": "http://localhost:8080"
+    }
+  }
+}

--- a/apps/mobile/babel.config.js
+++ b/apps/mobile/babel.config.js
@@ -1,0 +1,7 @@
+module.exports = function (api) {
+  api.cache(true);
+  return {
+    presets: ['babel-preset-expo'],
+    plugins: ['react-native-reanimated/plugin']
+  };
+};

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -1,0 +1,43 @@
+{
+  "name": "ippan-unified-mobile",
+  "version": "0.1.0",
+  "private": true,
+  "main": "node_modules/expo/AppEntry.js",
+  "scripts": {
+    "start": "expo start --clear",
+    "android": "expo run:android",
+    "ios": "expo run:ios",
+    "lint": "ESLINT_USE_FLAT_CONFIG=false eslint --ext .ts,.tsx .",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@expo/vector-icons": "^14.0.2",
+    "@react-native-async-storage/async-storage": "^1.23.1",
+    "@react-navigation/bottom-tabs": "^6.5.20",
+    "@react-navigation/native": "^6.1.17",
+    "@react-navigation/native-stack": "^6.9.26",
+    "@tanstack/react-query": "^5.51.23",
+    "axios": "^1.7.7",
+    "expo": "~51.0.4",
+    "expo-status-bar": "~1.12.1",
+    "react": "18.2.0",
+    "react-native": "0.74.3",
+    "react-native-gesture-handler": "~2.16.1",
+    "react-native-reanimated": "~3.10.1",
+    "react-native-safe-area-context": "4.10.5",
+    "react-native-screens": "~3.31.1",
+    "expo-crypto": "~12.8.0"
+  },
+  "devDependencies": {
+    "@babel/core": "^7.24.7",
+    "@types/react": "~18.2.45",
+    "@types/react-native": "~0.73.0",
+    "@typescript-eslint/eslint-plugin": "^6.14.0",
+    "@typescript-eslint/parser": "^6.14.0",
+    "babel-preset-expo": "^11.0.4",
+    "eslint": "^8.55.0",
+    "eslint-plugin-react": "^7.33.2",
+    "eslint-plugin-react-hooks": "^4.6.0",
+    "typescript": "^5.5.4"
+  }
+}

--- a/apps/mobile/src/api/index.ts
+++ b/apps/mobile/src/api/index.ts
@@ -1,0 +1,346 @@
+import { AxiosInstance, AxiosRequestConfig, isAxiosError } from 'axios';
+
+export interface WalletBalance {
+  account: string;
+  balance: number;
+  staked: number;
+  nonce: number;
+  rewards?: number;
+  pendingTransactions?: string[];
+}
+
+export interface WalletTransaction {
+  id: string;
+  txHash?: string;
+  from: string;
+  to: string;
+  amount: number;
+  fee?: number;
+  memo?: string;
+  timestamp: string;
+  type?: string;
+  status?: string;
+}
+
+export interface SubmitPaymentInput {
+  from: string;
+  to: string;
+  amount: number;
+  fee: number;
+  nonce: number;
+  memo?: string;
+  signature: string;
+}
+
+export interface SubmitPaymentResponse {
+  success: boolean;
+  txId?: string;
+  message?: string;
+}
+
+export interface NodeStatus {
+  node_id?: string;
+  status?: string;
+  current_block?: number;
+  total_transactions?: number;
+  network_peers?: number;
+  uptime_seconds?: number;
+  version?: string;
+  recent_blocks?: Array<Record<string, unknown>>;
+  blocks?: Array<Record<string, unknown>>;
+  node?: {
+    is_running: boolean;
+    uptime_seconds: number;
+    version: string;
+    node_id: string;
+  };
+  network?: {
+    connected_peers: number;
+    known_peers: number;
+    total_peers: number;
+  };
+  mempool?: {
+    total_transactions: number;
+    pending_transactions: number;
+  };
+  blockchain?: {
+    current_height: number;
+    total_blocks: number;
+    total_transactions: number;
+  };
+}
+
+export interface NetworkStats {
+  total_peers: number;
+  connected_peers: number;
+  network_id?: string;
+  protocol_version?: string;
+  uptime_seconds?: number;
+}
+
+export interface MempoolStats {
+  total_transactions: number;
+  total_senders?: number;
+  total_size?: number;
+  fee_distribution?: Record<string, number>;
+}
+
+export interface ConsensusStats {
+  current_round: number;
+  validators_count: number;
+  block_height: number;
+  consensus_status: string;
+}
+
+export interface HealthStatus {
+  status: string;
+  timestamp?: string;
+  network?: string;
+}
+
+export interface ModelAsset {
+  id: string;
+  owner: string;
+  name?: string;
+  description?: string;
+  arch_id?: number;
+  version?: number;
+  weights_hash?: string;
+  size_bytes?: number;
+  license_id?: number;
+  created_at?: { us: number; round_id: number };
+}
+
+export interface DatasetAsset {
+  id: string;
+  owner: string;
+  name: string;
+  description?: string;
+  size_bytes?: number;
+  created_at?: { us: number; round_id: number };
+}
+
+const GET_OPTIONS: AxiosRequestConfig = {
+  timeout: 12_000
+};
+
+function toNumber(value: unknown): number {
+  if (typeof value === 'number') {
+    return value;
+  }
+  if (typeof value === 'string') {
+    const parsed = Number(value);
+    if (Number.isFinite(parsed)) {
+      return parsed;
+    }
+  }
+  return 0;
+}
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  if (value && typeof value === 'object' && !Array.isArray(value)) {
+    return value as Record<string, unknown>;
+  }
+  return null;
+}
+
+function asArray(value: unknown): unknown[] | null {
+  return Array.isArray(value) ? value : null;
+}
+
+function getString(record: Record<string, unknown>, key: string): string | undefined {
+  const value = record[key];
+  return typeof value === 'string' ? value : undefined;
+}
+
+function parseCreatedAt(value: unknown): { us: number; round_id: number } | undefined {
+  const record = asRecord(value);
+  if (!record) {
+    return undefined;
+  }
+  const usValue = record.us;
+  const roundValue = record.round_id;
+  if (typeof usValue === 'number' && typeof roundValue === 'number') {
+    return { us: usValue, round_id: roundValue };
+  }
+  return undefined;
+}
+
+function normaliseWalletBalance(payload: unknown, address: string): WalletBalance {
+  const payloadRecord = asRecord(payload);
+  const dataRecord = payloadRecord?.data ? asRecord(payloadRecord.data) ?? payloadRecord : payloadRecord;
+
+  if (!dataRecord) {
+    return {
+      account: address,
+      balance: 0,
+      staked: 0,
+      nonce: 0
+    };
+  }
+
+  const account = getString(dataRecord, 'account') ?? getString(dataRecord, 'address') ?? address;
+  const pendingRaw = dataRecord.pending_transactions;
+  const pendingTransactions = Array.isArray(pendingRaw)
+    ? pendingRaw.map((item) => String(item))
+    : undefined;
+
+  return {
+    account,
+    balance: toNumber(dataRecord.balance ?? dataRecord.available ?? 0),
+    staked: toNumber(dataRecord.staked ?? dataRecord.staked_amount ?? 0),
+    rewards: toNumber(dataRecord.rewards ?? 0),
+    nonce: toNumber(dataRecord.nonce ?? 0),
+    pendingTransactions
+  };
+}
+
+export async function fetchWalletBalance(client: AxiosInstance, address: string): Promise<WalletBalance> {
+  try {
+    const { data } = await client.get(`/api/v1/balance/${address}`, GET_OPTIONS);
+    return normaliseWalletBalance(data, address);
+  } catch (error) {
+    if (isAxiosError(error) && error.response?.status === 404) {
+      return normaliseWalletBalance({}, address);
+    }
+    const { data } = await client.get('/api/v1/balance', {
+      ...GET_OPTIONS,
+      params: { address }
+    });
+    return normaliseWalletBalance(data, address);
+  }
+}
+
+export async function fetchWalletTransactions(client: AxiosInstance, address: string): Promise<WalletTransaction[]> {
+  const { data } = await client.get('/api/v1/transactions', {
+    ...GET_OPTIONS,
+    params: { address }
+  });
+
+  const dataRecord = asRecord(data);
+  const rows = asArray(data) ?? asArray(dataRecord?.transactions) ?? [];
+
+  return rows.map((entry, index) => {
+    const row = asRecord(entry) ?? {};
+    return {
+      id: String(row.id ?? row.tx_hash ?? `tx-${index}`),
+      txHash: row.tx_hash ? String(row.tx_hash) : undefined,
+      from: String(row.from ?? row.sender ?? ''),
+      to: String(row.to ?? row.recipient ?? ''),
+      amount: toNumber(row.amount ?? row.value ?? 0),
+      fee: toNumber(row.fee ?? row.fee_paid ?? 0),
+      memo: row.memo ? String(row.memo) : undefined,
+      timestamp: row.timestamp ? String(row.timestamp) : new Date().toISOString(),
+      type: row.type ? String(row.type) : undefined,
+      status: row.status ? String(row.status) : undefined
+    };
+  });
+}
+
+export async function submitPayment(client: AxiosInstance, payload: SubmitPaymentInput): Promise<SubmitPaymentResponse> {
+  try {
+    const { data } = await client.post('/api/v1/transaction', payload);
+    const success = Boolean(data?.success ?? data?.ok ?? data?.status === 'ok');
+    const txIdCandidate =
+      data?.data?.tx_hash ??
+      data?.tx_id ??
+      data?.hash ??
+      data?.txHash ??
+      data?.transaction_hash;
+    return {
+      success,
+      txId: txIdCandidate ? String(txIdCandidate) : undefined,
+      message: data?.message || data?.error
+    };
+  } catch (error) {
+    if (isAxiosError(error)) {
+      return {
+        success: false,
+        message: error.response?.data?.error || error.response?.data?.message || error.message
+      };
+    }
+    return { success: false, message: 'Failed to submit transaction' };
+  }
+}
+
+export type DomainRecord = Record<string, unknown> & {
+  name?: string;
+  domain?: string;
+  owner?: string;
+  expires_at?: string | number;
+};
+
+export async function fetchDomains(client: AxiosInstance): Promise<DomainRecord[]> {
+  const { data } = await client.get('/api/domains', GET_OPTIONS);
+  const dataRecord = asRecord(data);
+  const rows = asArray(data) ?? asArray(dataRecord?.domains) ?? [];
+  return rows.map((entry) => (asRecord(entry) ?? {}) as DomainRecord);
+}
+
+export async function fetchNodeStatus(client: AxiosInstance): Promise<NodeStatus> {
+  const { data } = await client.get('/api/v1/status', GET_OPTIONS);
+  return data;
+}
+
+export async function fetchNetworkStats(client: AxiosInstance): Promise<NetworkStats> {
+  const { data } = await client.get('/api/v1/network', GET_OPTIONS);
+  return data;
+}
+
+export async function fetchMempoolStats(client: AxiosInstance): Promise<MempoolStats> {
+  const { data } = await client.get('/api/v1/mempool', GET_OPTIONS);
+  return data;
+}
+
+export async function fetchConsensusStats(client: AxiosInstance): Promise<ConsensusStats> {
+  const { data } = await client.get('/api/v1/consensus', GET_OPTIONS);
+  return data;
+}
+
+export async function fetchHealth(client: AxiosInstance): Promise<HealthStatus> {
+  const { data } = await client.get('/health', GET_OPTIONS);
+  if (typeof data === 'string') {
+    return { status: data };
+  }
+  return data;
+}
+
+export async function fetchModels(client: AxiosInstance): Promise<ModelAsset[]> {
+  const { data } = await client.get('/api/models', GET_OPTIONS);
+  const dataRecord = asRecord(data);
+  const rows = asArray(data) ?? asArray(dataRecord?.models) ?? [];
+  return rows.map((entry, index) => {
+    const record = asRecord(entry) ?? {};
+    const size = toNumber(record.size_bytes ?? record.sizeBytes ?? 0);
+    return {
+      id: typeof record.id === 'string' ? record.id : `model-${index}`,
+      owner: typeof record.owner === 'string' ? record.owner : '',
+      name: typeof record.name === 'string' ? record.name : undefined,
+      description: typeof record.description === 'string' ? record.description : undefined,
+      arch_id: typeof record.arch_id === 'number' ? record.arch_id : undefined,
+      version: typeof record.version === 'number' ? record.version : undefined,
+      weights_hash: typeof record.weights_hash === 'string' ? record.weights_hash : undefined,
+      size_bytes: size > 0 ? size : undefined,
+      license_id: typeof record.license_id === 'number' ? record.license_id : undefined,
+      created_at: parseCreatedAt(record.created_at)
+    } satisfies ModelAsset;
+  });
+}
+
+export async function fetchDatasets(client: AxiosInstance): Promise<DatasetAsset[]> {
+  const { data } = await client.get('/api/datasets', GET_OPTIONS);
+  const dataRecord = asRecord(data);
+  const rows = asArray(data) ?? asArray(dataRecord?.datasets) ?? [];
+  return rows.map((entry, index) => {
+    const record = asRecord(entry) ?? {};
+    const size = toNumber(record.size_bytes ?? record.sizeBytes ?? 0);
+    return {
+      id: typeof record.id === 'string' ? record.id : `dataset-${index}`,
+      owner: typeof record.owner === 'string' ? record.owner : '',
+      name: typeof record.name === 'string' ? record.name : `Dataset #${index + 1}`,
+      description: typeof record.description === 'string' ? record.description : undefined,
+      size_bytes: size > 0 ? size : undefined,
+      created_at: parseCreatedAt(record.created_at)
+    } satisfies DatasetAsset;
+  });
+}

--- a/apps/mobile/src/components/Button.tsx
+++ b/apps/mobile/src/components/Button.tsx
@@ -1,0 +1,68 @@
+import React from 'react';
+import { Pressable, Text, StyleSheet, ViewStyle } from 'react-native';
+
+type ButtonVariant = 'primary' | 'secondary' | 'ghost';
+
+type ButtonProps = {
+  label: string;
+  onPress: () => void;
+  disabled?: boolean;
+  variant?: ButtonVariant;
+  style?: ViewStyle | ViewStyle[];
+};
+
+export function Button({ label, onPress, disabled = false, variant = 'primary', style }: ButtonProps) {
+  return (
+    <Pressable
+      accessibilityRole="button"
+      onPress={disabled ? undefined : onPress}
+      style={({ pressed }) => [
+        styles.base,
+        variantStyles[variant],
+        disabled ? styles.disabled : null,
+        pressed && !disabled ? styles.pressed : null,
+        style
+      ]}
+    >
+      <Text style={[styles.label, variant === 'ghost' ? styles.ghostLabel : null]}>{label}</Text>
+    </Pressable>
+  );
+}
+
+const styles = StyleSheet.create({
+  base: {
+    borderRadius: 12,
+    paddingVertical: 12,
+    paddingHorizontal: 18,
+    alignItems: 'center',
+    justifyContent: 'center'
+  },
+  pressed: {
+    opacity: 0.85
+  },
+  disabled: {
+    opacity: 0.5
+  },
+  label: {
+    fontSize: 15,
+    fontWeight: '600',
+    color: '#0f172a'
+  },
+  ghostLabel: {
+    color: '#f8fafc'
+  }
+});
+
+const variantStyles: Record<ButtonVariant, ViewStyle> = {
+  primary: {
+    backgroundColor: '#38bdf8'
+  },
+  secondary: {
+    backgroundColor: '#1d4ed8'
+  },
+  ghost: {
+    backgroundColor: 'transparent',
+    borderWidth: 1,
+    borderColor: '#38bdf8'
+  }
+};

--- a/apps/mobile/src/components/Card.tsx
+++ b/apps/mobile/src/components/Card.tsx
@@ -1,0 +1,67 @@
+import React from 'react';
+import { View, Text, StyleSheet, ViewStyle } from 'react-native';
+
+type CardProps = {
+  title?: string;
+  subtitle?: string;
+  action?: React.ReactNode;
+  children: React.ReactNode;
+  style?: ViewStyle | ViewStyle[];
+};
+
+export function Card({ title, subtitle, action, children, style }: CardProps) {
+  return (
+    <View style={[styles.card, style]}> 
+      {(title || action || subtitle) && (
+        <View style={styles.header}>
+          <View style={styles.headerTextContainer}>
+            {title ? <Text style={styles.title}>{title}</Text> : null}
+            {subtitle ? <Text style={styles.subtitle}>{subtitle}</Text> : null}
+          </View>
+          {action ? <View>{action}</View> : null}
+        </View>
+      )}
+      <View style={styles.body}>{children}</View>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  card: {
+    backgroundColor: '#111c33',
+    borderRadius: 18,
+    paddingHorizontal: 18,
+    paddingVertical: 20,
+    marginBottom: 16,
+    shadowColor: '#000',
+    shadowOpacity: 0.25,
+    shadowRadius: 12,
+    shadowOffset: { width: 0, height: 4 },
+    elevation: 4,
+    borderWidth: 1,
+    borderColor: '#1f2a44'
+  },
+  header: {
+    flexDirection: 'row',
+    alignItems: 'flex-start',
+    justifyContent: 'space-between',
+    marginBottom: 16
+  },
+  headerTextContainer: {
+    flex: 1,
+    paddingRight: 12
+  },
+  title: {
+    fontSize: 18,
+    fontWeight: '700',
+    color: '#f8fafc',
+    marginBottom: 4
+  },
+  subtitle: {
+    fontSize: 13,
+    color: '#94a3b8'
+  },
+  body: {
+    gap: 12
+  }
+});

--- a/apps/mobile/src/components/InfoRow.tsx
+++ b/apps/mobile/src/components/InfoRow.tsx
@@ -1,0 +1,52 @@
+import React from 'react';
+import { View, Text, StyleSheet, ViewStyle } from 'react-native';
+
+type InfoRowProps = {
+  label: string;
+  value: React.ReactNode;
+  style?: ViewStyle | ViewStyle[];
+  align?: 'center' | 'top';
+};
+
+export function InfoRow({ label, value, style, align = 'center' }: InfoRowProps) {
+  const valueElement =
+    typeof value === 'string' || typeof value === 'number' ? (
+      <Text style={styles.valueText}>{value}</Text>
+    ) : (
+      value
+    );
+
+  return (
+    <View style={[styles.row, align === 'top' ? styles.alignTop : null, style]}>
+      <Text style={styles.label}>{label}</Text>
+      <View style={styles.value}>{valueElement}</View>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  row: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    gap: 12
+  },
+  alignTop: {
+    alignItems: 'flex-start'
+  },
+  label: {
+    flex: 1,
+    fontSize: 14,
+    color: '#cbd5f5',
+    fontWeight: '600'
+  },
+  value: {
+    flex: 1.2,
+    alignItems: 'flex-end'
+  },
+  valueText: {
+    fontSize: 15,
+    color: '#f1f5f9',
+    textAlign: 'right'
+  }
+});

--- a/apps/mobile/src/components/Tag.tsx
+++ b/apps/mobile/src/components/Tag.tsx
@@ -1,0 +1,38 @@
+import React from 'react';
+import { View, Text, StyleSheet, ViewStyle } from 'react-native';
+
+type TagProps = {
+  label: string;
+  tone?: 'info' | 'success' | 'warning' | 'danger' | 'neutral';
+  style?: ViewStyle | ViewStyle[];
+};
+
+const toneStyles: Record<NonNullable<TagProps['tone']>, { backgroundColor: string; color: string }> = {
+  info: { backgroundColor: 'rgba(59, 130, 246, 0.15)', color: '#93c5fd' },
+  success: { backgroundColor: 'rgba(16, 185, 129, 0.15)', color: '#6ee7b7' },
+  warning: { backgroundColor: 'rgba(234, 179, 8, 0.15)', color: '#fde68a' },
+  danger: { backgroundColor: 'rgba(248, 113, 113, 0.15)', color: '#fca5a5' },
+  neutral: { backgroundColor: 'rgba(148, 163, 184, 0.15)', color: '#cbd5f5' }
+};
+
+export function Tag({ label, tone = 'neutral', style }: TagProps) {
+  const palette = toneStyles[tone];
+  return (
+    <View style={[styles.container, { backgroundColor: palette.backgroundColor }, style]}>
+      <Text style={[styles.text, { color: palette.color }]}>{label}</Text>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    paddingHorizontal: 10,
+    paddingVertical: 4,
+    borderRadius: 999,
+    alignSelf: 'flex-start'
+  },
+  text: {
+    fontSize: 12,
+    fontWeight: '600'
+  }
+});

--- a/apps/mobile/src/data/domainUpdates.ts
+++ b/apps/mobile/src/data/domainUpdates.ts
@@ -1,0 +1,153 @@
+export type DomainUpdateType = 'registration' | 'renewal' | 'transfer' | 'dns_change' | 'expiration' | 'tld_update';
+
+export interface DomainUpdate {
+  id: string;
+  type: DomainUpdateType;
+  domain: string;
+  description: string;
+  timestamp: string;
+  status: 'pending' | 'completed' | 'failed';
+  txHash?: string;
+  blockHeight?: number;
+  details?: Record<string, unknown>;
+}
+
+export interface DnsUpdate {
+  id: string;
+  domain: string;
+  recordType: string;
+  recordName: string;
+  oldValue?: string;
+  newValue: string;
+  timestamp: string;
+  status: 'pending' | 'completed' | 'failed';
+  txHash?: string;
+  blockHeight?: number;
+}
+
+export interface TldUpdate {
+  id: string;
+  tld: string;
+  type: 'new_tld' | 'price_change' | 'availability_change';
+  description: string;
+  timestamp: string;
+  oldPrice?: number;
+  newPrice?: number;
+  status: 'active' | 'inactive';
+}
+
+export const mockDomainUpdates: DomainUpdate[] = [
+  {
+    id: '1',
+    type: 'registration',
+    domain: 'alice.ipn',
+    description: 'New domain registered',
+    timestamp: new Date(Date.now() - 2 * 60 * 60 * 1000).toISOString(),
+    status: 'completed',
+    txHash: '0x1234567890abcdef1234567890abcdef12345678',
+    blockHeight: 12345,
+    details: { duration_years: 1, fee_paid: 1_000_000 }
+  },
+  {
+    id: '2',
+    type: 'renewal',
+    domain: 'bob.ai',
+    description: 'Domain renewed for 2 years',
+    timestamp: new Date(Date.now() - 4 * 60 * 60 * 1000).toISOString(),
+    status: 'completed',
+    txHash: '0xabcdef1234567890abcdef1234567890abcdef12',
+    blockHeight: 12340,
+    details: { duration_years: 2, fee_paid: 2_000_000 }
+  },
+  {
+    id: '3',
+    type: 'transfer',
+    domain: 'charlie.iot',
+    description: 'Domain ownership transferred',
+    timestamp: new Date(Date.now() - 6 * 60 * 60 * 1000).toISOString(),
+    status: 'pending',
+    txHash: '0x9876543210fedcba9876543210fedcba98765432',
+    blockHeight: 12335,
+    details: {
+      from: 'i1A1zP1eP5QGefi2DMPTfTL5SLmv7DivfNa',
+      to: 'i1B2zP2eP6QGefi3DMPTfTL6SLmv8DivfNb'
+    }
+  },
+  {
+    id: '4',
+    type: 'expiration',
+    domain: 'david.fin',
+    description: 'Domain expires in 30 days',
+    timestamp: new Date(Date.now() - 8 * 60 * 60 * 1000).toISOString(),
+    status: 'pending',
+    details: { expires_in_days: 30 }
+  }
+];
+
+export const mockDnsUpdates: DnsUpdate[] = [
+  {
+    id: '1',
+    domain: 'alice.ipn',
+    recordType: 'A',
+    recordName: '@',
+    oldValue: '192.168.1.1',
+    newValue: '192.168.1.2',
+    timestamp: new Date(Date.now() - 1 * 60 * 60 * 1000).toISOString(),
+    status: 'completed',
+    txHash: '0x1111111111111111111111111111111111111111',
+    blockHeight: 12344
+  },
+  {
+    id: '2',
+    domain: 'bob.ai',
+    recordType: 'CNAME',
+    recordName: 'www',
+    newValue: 'bob.ai',
+    timestamp: new Date(Date.now() - 3 * 60 * 60 * 1000).toISOString(),
+    status: 'completed',
+    txHash: '0x2222222222222222222222222222222222222222',
+    blockHeight: 12341
+  },
+  {
+    id: '3',
+    domain: 'charlie.iot',
+    recordType: 'TXT',
+    recordName: '@',
+    newValue: 'v=spf1 include:_spf.google.com ~all',
+    timestamp: new Date(Date.now() - 5 * 60 * 60 * 1000).toISOString(),
+    status: 'pending',
+    txHash: '0x3333333333333333333333333333333333333333',
+    blockHeight: 12336
+  }
+];
+
+export const mockTldUpdates: TldUpdate[] = [
+  {
+    id: '1',
+    tld: '.ai',
+    type: 'price_change',
+    description: 'Premium TLD price updated',
+    timestamp: new Date(Date.now() - 12 * 60 * 60 * 1000).toISOString(),
+    oldPrice: 10_000_000,
+    newPrice: 12_000_000,
+    status: 'active'
+  },
+  {
+    id: '2',
+    tld: '.iot',
+    type: 'availability_change',
+    description: 'New TLD available for registration',
+    timestamp: new Date(Date.now() - 24 * 60 * 60 * 1000).toISOString(),
+    newPrice: 2_000_000,
+    status: 'active'
+  },
+  {
+    id: '3',
+    tld: '.fin',
+    type: 'new_tld',
+    description: 'New premium TLD launched',
+    timestamp: new Date(Date.now() - 48 * 60 * 60 * 1000).toISOString(),
+    newPrice: 15_000_000,
+    status: 'active'
+  }
+];

--- a/apps/mobile/src/data/nodes.ts
+++ b/apps/mobile/src/data/nodes.ts
@@ -1,0 +1,40 @@
+export interface NodeOption {
+  id: string;
+  label: string;
+  baseUrl: string;
+  region: string;
+  latencyMs: number;
+  isCommunity?: boolean;
+}
+
+export const defaultNodes: NodeOption[] = [
+  {
+    id: 'validator-eu-1',
+    label: 'Validator • EU West',
+    baseUrl: 'https://validator.eu-west.ippan.network',
+    region: 'Frankfurt, DE',
+    latencyMs: 92
+  },
+  {
+    id: 'validator-us-1',
+    label: 'Validator • US East',
+    baseUrl: 'https://validator.us-east.ippan.network',
+    region: 'Ashburn, US',
+    latencyMs: 64
+  },
+  {
+    id: 'gateway-apac',
+    label: 'Gateway • APAC',
+    baseUrl: 'https://gateway.apac.ippan.network',
+    region: 'Singapore',
+    latencyMs: 138
+  },
+  {
+    id: 'community-latam',
+    label: 'Community Node • LATAM',
+    baseUrl: 'https://latam.community.ippan.network',
+    region: 'São Paulo, BR',
+    latencyMs: 182,
+    isCommunity: true
+  }
+];

--- a/apps/mobile/src/providers/ApiProvider.tsx
+++ b/apps/mobile/src/providers/ApiProvider.tsx
@@ -1,0 +1,123 @@
+import React, { createContext, useCallback, useContext, useEffect, useMemo, useState } from 'react';
+import { View, ActivityIndicator, StyleSheet } from 'react-native';
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import axios, { AxiosInstance } from 'axios';
+import Constants from 'expo-constants';
+
+const STORAGE_KEY = 'ippan.mobile.api.baseUrl';
+
+type ConstantsWithManifest = typeof Constants & {
+  manifest?: {
+    extra?: Record<string, unknown>;
+  };
+};
+
+const expoConfigExtra = (Constants?.expoConfig?.extra ?? null) as Record<string, unknown> | null;
+const legacyExtra = (Constants as ConstantsWithManifest).manifest?.extra ?? null;
+const extra = expoConfigExtra ?? legacyExtra ?? {};
+const DEFAULT_BASE_URL = typeof extra.defaultApiBaseUrl === 'string' ? extra.defaultApiBaseUrl : 'http://localhost:8080';
+
+export interface ApiContextValue {
+  baseUrl: string;
+  client: AxiosInstance;
+  setBaseUrl: (url: string) => void;
+  isReady: boolean;
+}
+
+const ApiContext = createContext<ApiContextValue | undefined>(undefined);
+
+function normalizeUrl(url: string): string {
+  const trimmed = url.trim();
+  if (!trimmed) {
+    return DEFAULT_BASE_URL;
+  }
+  if (/^https?:\/\//i.test(trimmed)) {
+    return trimmed.replace(/\/$/, '');
+  }
+  return `http://${trimmed.replace(/\/$/, '')}`;
+}
+
+export const ApiProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+  const [baseUrl, setBaseUrlState] = useState<string>(DEFAULT_BASE_URL);
+  const [isReady, setIsReady] = useState(false);
+
+  useEffect(() => {
+    let mounted = true;
+
+    AsyncStorage.getItem(STORAGE_KEY)
+      .then((stored) => {
+        if (stored && mounted) {
+          setBaseUrlState(stored);
+        }
+      })
+      .catch((error) => {
+        console.warn('Failed to load API base URL from storage', error);
+      })
+      .finally(() => {
+        if (mounted) {
+          setIsReady(true);
+        }
+      });
+
+    return () => {
+      mounted = false;
+    };
+  }, []);
+
+  const setBaseUrl = useCallback((url: string) => {
+    const normalized = normalizeUrl(url);
+    setBaseUrlState(normalized);
+    AsyncStorage.setItem(STORAGE_KEY, normalized).catch((error) => {
+      console.warn('Failed to persist API base URL', error);
+    });
+  }, []);
+
+  const client = useMemo(() => {
+    const instance = axios.create({
+      baseURL: baseUrl,
+      headers: {
+        'Content-Type': 'application/json'
+      },
+      timeout: 12_000
+    });
+
+    return instance;
+  }, [baseUrl]);
+
+  const value = useMemo<ApiContextValue>(
+    () => ({
+      baseUrl,
+      client,
+      setBaseUrl,
+      isReady
+    }),
+    [baseUrl, client, setBaseUrl, isReady]
+  );
+
+  if (!isReady) {
+    return (
+      <View style={styles.loadingContainer}>
+        <ActivityIndicator color="#38bdf8" size="large" />
+      </View>
+    );
+  }
+
+  return <ApiContext.Provider value={value}>{children}</ApiContext.Provider>;
+};
+
+export function useApi(): ApiContextValue {
+  const context = useContext(ApiContext);
+  if (!context) {
+    throw new Error('useApi must be used within an ApiProvider');
+  }
+  return context;
+}
+
+const styles = StyleSheet.create({
+  loadingContainer: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+    backgroundColor: '#0f172a'
+  }
+});

--- a/apps/mobile/src/providers/WalletProvider.tsx
+++ b/apps/mobile/src/providers/WalletProvider.tsx
@@ -1,0 +1,135 @@
+import React, { createContext, useCallback, useContext, useEffect, useMemo, useState } from 'react';
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import * as Crypto from 'expo-crypto';
+
+export type WalletType = 'watch-only' | 'local';
+
+interface WalletContextValue {
+  walletAddress: string | null;
+  walletType: WalletType;
+  isReady: boolean;
+  setWatchAddress: (address: string) => Promise<void>;
+  connectLocalWallet: () => Promise<string>;
+  disconnectWallet: () => Promise<void>;
+  signMessage: (message: string) => Promise<string>;
+}
+
+const WalletContext = createContext<WalletContextValue | undefined>(undefined);
+
+const ADDRESS_KEY = 'ippan.wallet.address';
+const TYPE_KEY = 'ippan.wallet.type';
+
+const ADDRESS_REGEX = /^i[0-9a-fA-F]{64}$/;
+
+function randomHex(length: number): string {
+  let output = '';
+  while (output.length < length) {
+    output += Math.floor(Math.random() * 16).toString(16);
+  }
+  return output.slice(0, length);
+}
+
+export const WalletProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+  const [walletAddress, setWalletAddress] = useState<string | null>(null);
+  const [walletType, setWalletType] = useState<WalletType>('watch-only');
+  const [isReady, setIsReady] = useState(false);
+
+  useEffect(() => {
+    let mounted = true;
+
+    AsyncStorage.multiGet([ADDRESS_KEY, TYPE_KEY])
+      .then((entries) => {
+        if (!mounted) return;
+        const storedAddress = entries[0]?.[1];
+        const storedType = (entries[1]?.[1] as WalletType | null) || 'watch-only';
+        if (storedAddress) {
+          setWalletAddress(storedAddress);
+        }
+        setWalletType(storedType);
+      })
+      .catch((error) => {
+        console.warn('Failed to load wallet state', error);
+      })
+      .finally(() => {
+        if (mounted) {
+          setIsReady(true);
+        }
+      });
+
+    return () => {
+      mounted = false;
+    };
+  }, []);
+
+  const persistState = useCallback(async (address: string | null, type: WalletType) => {
+    setWalletAddress(address);
+    setWalletType(type);
+    if (address) {
+      await AsyncStorage.multiSet([
+        [ADDRESS_KEY, address],
+        [TYPE_KEY, type]
+      ]);
+    } else {
+      await AsyncStorage.removeItem(ADDRESS_KEY);
+      await AsyncStorage.setItem(TYPE_KEY, type);
+    }
+  }, []);
+
+  const setWatchAddress = useCallback(
+    async (address: string) => {
+      const normalized = address.trim();
+      if (!ADDRESS_REGEX.test(normalized)) {
+        throw new Error('Addresses must start with i and contain 64 hexadecimal characters.');
+      }
+      await persistState(normalized, 'watch-only');
+    },
+    [persistState]
+  );
+
+  const connectLocalWallet = useCallback(async () => {
+    const generatedAddress = `i${randomHex(64)}`;
+    await persistState(generatedAddress, 'local');
+    return generatedAddress;
+  }, [persistState]);
+
+  const disconnectWallet = useCallback(async () => {
+    await persistState(null, 'watch-only');
+  }, [persistState]);
+
+  const signMessage = useCallback(
+    async (message: string) => {
+      if (walletType !== 'local' || !walletAddress) {
+        throw new Error('Only locally managed wallets can sign messages on mobile.');
+      }
+      const digest = await Crypto.digestStringAsync(
+        Crypto.CryptoDigestAlgorithm.SHA256,
+        `${walletAddress}:${message}`
+      );
+      return `sig_${digest.slice(0, 48)}`;
+    },
+    [walletAddress, walletType]
+  );
+
+  const value = useMemo<WalletContextValue>(
+    () => ({
+      walletAddress,
+      walletType,
+      isReady,
+      setWatchAddress,
+      connectLocalWallet,
+      disconnectWallet,
+      signMessage
+    }),
+    [walletAddress, walletType, isReady, setWatchAddress, connectLocalWallet, disconnectWallet, signMessage]
+  );
+
+  return <WalletContext.Provider value={value}>{children}</WalletContext.Provider>;
+};
+
+export function useWallet(): WalletContextValue {
+  const context = useContext(WalletContext);
+  if (!context) {
+    throw new Error('useWallet must be used within a WalletProvider');
+  }
+  return context;
+}

--- a/apps/mobile/src/screens/explorer/ExplorerScreen.tsx
+++ b/apps/mobile/src/screens/explorer/ExplorerScreen.tsx
@@ -1,0 +1,304 @@
+import React, { useCallback, useMemo, useState } from 'react';
+import { ActivityIndicator, RefreshControl, ScrollView, StyleSheet, Text, View } from 'react-native';
+import { useQuery } from '@tanstack/react-query';
+
+import { Card } from '../../components/Card';
+import { InfoRow } from '../../components/InfoRow';
+import { Tag } from '../../components/Tag';
+import { useApi } from '../../providers/ApiProvider';
+import {
+  fetchConsensusStats,
+  fetchMempoolStats,
+  fetchNetworkStats,
+  fetchNodeStatus
+} from '../../api';
+import { formatDateTime, formatNumber, formatPercent } from '../../utils/format';
+
+type BlockHistoryItem = {
+  id: string;
+  height: number;
+  transactions: number;
+  timestamp: string;
+  proposer: string;
+};
+
+const FALLBACK_BLOCKS: BlockHistoryItem[] = Array.from({ length: 6 }).map((_, index) => ({
+  id: `sim-block-${index}`,
+  height: 1_234_560 - index,
+  transactions: Math.floor(Math.random() * 120) + 12,
+  timestamp: new Date(Date.now() - index * 12_000).toISOString(),
+  proposer: `validator-${(index % 5) + 1}`
+}));
+
+function coerceBlockHistoryItem(entry: unknown, index: number): BlockHistoryItem {
+  const record = entry && typeof entry === 'object' && !Array.isArray(entry) ? (entry as Record<string, unknown>) : {};
+  const idValue = record.id ?? record.hash ?? `block-${index}`;
+  const heightValue = record.height ?? record.block_height ?? record.number ?? 0;
+  const txValue = record.transactions ?? record.tx_count ?? 0;
+  const timestampValue = record.timestamp;
+
+  const id = typeof idValue === 'string' ? idValue : `block-${index}`;
+  const heightNumber = typeof heightValue === 'number' ? heightValue : Number(heightValue);
+  const transactionsNumber = typeof txValue === 'number' ? txValue : Number(txValue);
+  const timestamp =
+    typeof timestampValue === 'string'
+      ? timestampValue
+      : typeof timestampValue === 'number'
+      ? new Date(timestampValue).toISOString()
+      : new Date().toISOString();
+  const proposer =
+    typeof record.proposer === 'string'
+      ? record.proposer
+      : typeof record.validator === 'string'
+      ? record.validator
+      : 'unknown';
+
+  return {
+    id,
+    height: Number.isFinite(heightNumber) ? heightNumber : 0,
+    transactions: Number.isFinite(transactionsNumber) ? transactionsNumber : 0,
+    timestamp,
+    proposer
+  };
+}
+
+export default function ExplorerScreen() {
+  const { client, baseUrl } = useApi();
+  const [refreshing, setRefreshing] = useState(false);
+
+  const nodeStatusQuery = useQuery({
+    queryKey: ['node-status', baseUrl],
+    queryFn: () => fetchNodeStatus(client),
+    staleTime: 15_000
+  });
+
+  const networkStatsQuery = useQuery({
+    queryKey: ['network-stats', baseUrl],
+    queryFn: () => fetchNetworkStats(client),
+    staleTime: 30_000
+  });
+
+  const mempoolStatsQuery = useQuery({
+    queryKey: ['mempool-stats', baseUrl],
+    queryFn: () => fetchMempoolStats(client),
+    staleTime: 15_000
+  });
+
+  const consensusStatsQuery = useQuery({
+    queryKey: ['consensus-stats', baseUrl],
+    queryFn: () => fetchConsensusStats(client),
+    staleTime: 15_000
+  });
+
+  const onRefresh = useCallback(async () => {
+    try {
+      setRefreshing(true);
+      await Promise.all([
+        nodeStatusQuery.refetch(),
+        networkStatsQuery.refetch(),
+        mempoolStatsQuery.refetch(),
+        consensusStatsQuery.refetch()
+      ]);
+    } finally {
+      setRefreshing(false);
+    }
+  }, [nodeStatusQuery, networkStatsQuery, mempoolStatsQuery, consensusStatsQuery]);
+
+  const blockHistory = useMemo<BlockHistoryItem[]>(() => {
+    const source = nodeStatusQuery.data?.recent_blocks || nodeStatusQuery.data?.blocks;
+    if (Array.isArray(source) && source.length > 0) {
+      return source.slice(0, 6).map((block, index) => coerceBlockHistoryItem(block, index));
+    }
+    return FALLBACK_BLOCKS;
+  }, [nodeStatusQuery.data]);
+
+  const nodeHealthTag = useMemo(() => {
+    if (nodeStatusQuery.isError) {
+      return <Tag label="Offline" tone="danger" />;
+    }
+    if (nodeStatusQuery.data?.node?.is_running ?? false) {
+      return <Tag label="Online" tone="success" />;
+    }
+    if (nodeStatusQuery.data) {
+      return <Tag label="Syncing" tone="warning" />;
+    }
+    return <Tag label="Unknown" tone="neutral" />;
+  }, [nodeStatusQuery.isError, nodeStatusQuery.data]);
+
+  return (
+    <ScrollView
+      style={styles.container}
+      contentContainerStyle={styles.content}
+      refreshControl={<RefreshControl refreshing={refreshing} onRefresh={onRefresh} tintColor="#38bdf8" />}>
+      <Text style={styles.heading}>IPPAN Explorer</Text>
+      <Text style={styles.subheading}>
+        Inspect live validator telemetry, mempool pressure and consensus state from your configured node.
+      </Text>
+
+      <Card title="Node status" subtitle={`Connected to ${baseUrl}`} action={nodeHealthTag}>
+        {nodeStatusQuery.isLoading ? (
+          <ActivityIndicator color="#38bdf8" />
+        ) : nodeStatusQuery.isError ? (
+          <Text style={styles.placeholder}>Unable to reach the node. Pull to refresh after checking connectivity.</Text>
+        ) : (
+          <>
+            <InfoRow label="Node ID" value={nodeStatusQuery.data?.node?.node_id ?? nodeStatusQuery.data?.node_id ?? '—'} />
+            <InfoRow
+              label="Version"
+              value={nodeStatusQuery.data?.node?.version ?? nodeStatusQuery.data?.version ?? '—'}
+            />
+            <InfoRow
+              label="Uptime"
+              value={`${formatNumber((nodeStatusQuery.data?.node?.uptime_seconds ?? nodeStatusQuery.data?.uptime_seconds ?? 0) / 3600, {
+                maximumFractionDigits: 1
+              })} hours`}
+            />
+            <InfoRow
+              label="Current block"
+              value={nodeStatusQuery.data?.blockchain?.current_height ?? nodeStatusQuery.data?.current_block ?? '—'}
+            />
+          </>
+        )}
+      </Card>
+
+      <Card title="Network" subtitle="Peer connectivity and health across the configured cluster.">
+        {networkStatsQuery.isLoading ? (
+          <ActivityIndicator color="#38bdf8" />
+        ) : networkStatsQuery.isError ? (
+          <Text style={styles.placeholder}>Network statistics unavailable.</Text>
+        ) : (
+          <>
+            <InfoRow label="Connected peers" value={networkStatsQuery.data?.connected_peers ?? '—'} />
+            <InfoRow label="Total peers" value={networkStatsQuery.data?.total_peers ?? '—'} />
+            <InfoRow label="Network ID" value={networkStatsQuery.data?.network_id ?? '—'} />
+            <InfoRow label="Protocol" value={networkStatsQuery.data?.protocol_version ?? '—'} />
+          </>
+        )}
+      </Card>
+
+      <Card title="Mempool" subtitle="Pending transactions waiting for inclusion in upcoming blocks.">
+        {mempoolStatsQuery.isLoading ? (
+          <ActivityIndicator color="#38bdf8" />
+        ) : mempoolStatsQuery.isError ? (
+          <Text style={styles.placeholder}>Mempool information unavailable.</Text>
+        ) : (
+          <>
+            <InfoRow label="Transactions" value={mempoolStatsQuery.data?.total_transactions ?? 0} />
+            <InfoRow label="Senders" value={mempoolStatsQuery.data?.total_senders ?? 0} />
+            <InfoRow
+              label="Estimated size"
+              value={mempoolStatsQuery.data?.total_size ? `${formatNumber(mempoolStatsQuery.data.total_size)} bytes` : '—'}
+            />
+            {mempoolStatsQuery.data?.fee_distribution ? (
+              <View style={styles.feeBreakdown}>
+                {Object.entries(mempoolStatsQuery.data.fee_distribution).map(([tier, pct]) => (
+                  <View key={tier} style={styles.feeRow}>
+                    <Text style={styles.feeTier}>{tier}</Text>
+                    <Text style={styles.feeValue}>{formatPercent(pct)}</Text>
+                  </View>
+                ))}
+              </View>
+            ) : null}
+          </>
+        )}
+      </Card>
+
+      <Card title="Consensus" subtitle="Round progression and validator participation metrics.">
+        {consensusStatsQuery.isLoading ? (
+          <ActivityIndicator color="#38bdf8" />
+        ) : consensusStatsQuery.isError ? (
+          <Text style={styles.placeholder}>Consensus metrics unavailable.</Text>
+        ) : (
+          <>
+            <InfoRow label="Round" value={consensusStatsQuery.data?.current_round ?? '—'} />
+            <InfoRow label="Block height" value={consensusStatsQuery.data?.block_height ?? '—'} />
+            <InfoRow label="Validators" value={consensusStatsQuery.data?.validators_count ?? '—'} />
+            <InfoRow label="Status" value={consensusStatsQuery.data?.consensus_status ?? '—'} />
+          </>
+        )}
+      </Card>
+
+      <Card title="Recent blocks" subtitle="Last proposer rotations and throughput across the network.">
+        {blockHistory.map((block) => (
+          <View key={block.id} style={styles.blockItem}>
+            <View>
+              <Text style={styles.blockHeight}>#{block.height}</Text>
+              <Text style={styles.blockMeta}>Proposer {block.proposer}</Text>
+            </View>
+            <View style={{ alignItems: 'flex-end' }}>
+              <Text style={styles.blockTransactions}>{block.transactions} txs</Text>
+              <Text style={styles.blockMeta}>{formatDateTime(block.timestamp)}</Text>
+            </View>
+          </View>
+        ))}
+      </Card>
+    </ScrollView>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: '#0f172a'
+  },
+  content: {
+    padding: 20,
+    paddingBottom: 120
+  },
+  heading: {
+    fontSize: 28,
+    fontWeight: '700',
+    color: '#f8fafc',
+    marginBottom: 4
+  },
+  subheading: {
+    fontSize: 15,
+    color: '#94a3b8',
+    marginBottom: 20
+  },
+  placeholder: {
+    color: '#64748b',
+    fontSize: 14
+  },
+  feeBreakdown: {
+    marginTop: 10,
+    gap: 6
+  },
+  feeRow: {
+    flexDirection: 'row',
+    justifyContent: 'space-between'
+  },
+  feeTier: {
+    color: '#cbd5f5',
+    fontSize: 13
+  },
+  feeValue: {
+    color: '#38bdf8',
+    fontWeight: '600'
+  },
+  blockItem: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    backgroundColor: '#0b1220',
+    borderRadius: 12,
+    paddingHorizontal: 16,
+    paddingVertical: 12,
+    marginBottom: 12
+  },
+  blockHeight: {
+    color: '#f8fafc',
+    fontWeight: '700',
+    fontSize: 16
+  },
+  blockTransactions: {
+    color: '#38bdf8',
+    fontWeight: '600',
+    fontSize: 15
+  },
+  blockMeta: {
+    color: '#64748b',
+    fontSize: 12,
+    marginTop: 4
+  }
+});

--- a/apps/mobile/src/screens/neural/NeuralScreen.tsx
+++ b/apps/mobile/src/screens/neural/NeuralScreen.tsx
@@ -1,0 +1,253 @@
+import React, { useMemo } from 'react';
+import { ActivityIndicator, ScrollView, StyleSheet, Text, View } from 'react-native';
+import { useQuery } from '@tanstack/react-query';
+
+import { Card } from '../../components/Card';
+import { Tag } from '../../components/Tag';
+import { useApi } from '../../providers/ApiProvider';
+import { fetchDatasets, fetchModels } from '../../api';
+import { formatBytes, formatDateTime, formatNumber, truncateAddress } from '../../utils/format';
+
+const FALLBACK_MODELS = [
+  {
+    id: 'model-sentiment',
+    owner: 'i7f3e2aa90b91c0fe8dd7d1234567890abcdefabcdefabcdefabcdefabcdef',
+    name: 'Sentiment-classifier-v2',
+    version: 2,
+    arch_id: 42,
+    size_bytes: 86_000_000,
+    created_at: { us: Date.now() * 1000, round_id: 9234 }
+  },
+  {
+    id: 'model-vision',
+    owner: 'i1acbd00112233445566778899aabbccddeeff00112233445566778899aabb',
+    name: 'Vision-small-v5',
+    version: 5,
+    arch_id: 11,
+    size_bytes: 210_000_000,
+    created_at: { us: Date.now() * 1000 - 86_400_000_000, round_id: 9230 }
+  }
+];
+
+const FALLBACK_DATASETS = [
+  {
+    id: 'dataset-lidar',
+    owner: 'i4b8e2fa76b33221100ffeeddccbbaa99887766554433221100ffeeddccbbaa',
+    name: 'Autonomous LiDAR frames',
+    description: '4.5M annotated LiDAR frames with semantic classes',
+    size_bytes: 3_200_000_000,
+    created_at: { us: Date.now() * 1000 - 5_400_000_000, round_id: 9100 }
+  },
+  {
+    id: 'dataset-voice',
+    owner: 'i9000ddccbbaa11223344556677889900aabbccddeeff001122334455667788',
+    name: 'Conversational speech 32kHz',
+    description: 'Multilingual voice conversations with diarisation labels',
+    size_bytes: 1_100_000_000,
+    created_at: { us: Date.now() * 1000 - 8_640_000_000, round_id: 9050 }
+  }
+];
+
+const INFERENCE_JOBS = [
+  {
+    id: 'job-1',
+    model: 'Vision-small-v5',
+    status: 'completed',
+    latencyMs: 420,
+    tokens: 2048,
+    requester: 'i29f3949393aabbccddeeff11223344556677889900aabbccddeeff11223344',
+    timestamp: new Date(Date.now() - 12 * 60 * 1000).toISOString()
+  },
+  {
+    id: 'job-2',
+    model: 'Sentiment-classifier-v2',
+    status: 'running',
+    latencyMs: 1180,
+    tokens: 4096,
+    requester: 'i1888997766554433221100ffeeddccbbaa0099887766554433221100ffeedd',
+    timestamp: new Date(Date.now() - 4 * 60 * 1000).toISOString()
+  }
+];
+
+const BID_MARKET = [
+  { id: 'bid-1', dataset: 'Autonomous LiDAR frames', amount: 2400, bidder: 'validator-eu-1', status: 'leader' },
+  { id: 'bid-2', dataset: 'Conversational speech 32kHz', amount: 1800, bidder: 'gateway-apac', status: 'pending' }
+];
+
+const PROOF_EVENTS = [
+  { id: 'proof-1', type: 'ZK-SNARK', model: 'Vision-small-v5', status: 'verified', timestamp: new Date().toISOString() },
+  { id: 'proof-2', type: 'Attestation', model: 'Sentiment-classifier-v2', status: 'pending', timestamp: new Date(Date.now() - 3_600_000).toISOString() }
+];
+
+export default function NeuralScreen() {
+  const { client, baseUrl } = useApi();
+
+  const modelsQuery = useQuery({
+    queryKey: ['models', baseUrl],
+    queryFn: () => fetchModels(client),
+    staleTime: 60_000
+  });
+
+  const datasetsQuery = useQuery({
+    queryKey: ['datasets', baseUrl],
+    queryFn: () => fetchDatasets(client),
+    staleTime: 60_000
+  });
+
+  const models = useMemo(() => {
+    if (modelsQuery.isError || !modelsQuery.data || modelsQuery.data.length === 0) {
+      return FALLBACK_MODELS;
+    }
+    return modelsQuery.data.slice(0, 6);
+  }, [modelsQuery.data, modelsQuery.isError]);
+
+  const datasets = useMemo(() => {
+    if (datasetsQuery.isError || !datasetsQuery.data || datasetsQuery.data.length === 0) {
+      return FALLBACK_DATASETS;
+    }
+    return datasetsQuery.data.slice(0, 6);
+  }, [datasetsQuery.data, datasetsQuery.isError]);
+
+  return (
+    <ScrollView style={styles.container} contentContainerStyle={styles.content}>
+      <Text style={styles.heading}>Neural marketplace</Text>
+      <Text style={styles.subheading}>
+        Manage AI models, datasets and inference jobs across the IPPAN decentralised compute fabric.
+      </Text>
+
+      <Card title="Models" subtitle="Latest on-chain assets available for inference and training.">
+        {modelsQuery.isLoading ? (
+          <ActivityIndicator color="#38bdf8" />
+        ) : null}
+        {models.map((model) => (
+          <View key={model.id} style={styles.assetItem}>
+            <View style={{ flex: 1 }}>
+              <Text style={styles.assetTitle}>{model.name ?? model.id}</Text>
+              <Text style={styles.assetSubtitle}>Owner {truncateAddress(model.owner)}</Text>
+              <Text style={styles.assetMeta}>
+                Size {formatBytes(model.size_bytes ?? 0)} · Round {model.created_at?.round_id ?? '—'}
+              </Text>
+            </View>
+            <Tag label={`v${model.version ?? 1}`} tone="info" />
+          </View>
+        ))}
+      </Card>
+
+      <Card title="Datasets" subtitle="Curated data resources for federated training and fine-tuning.">
+        {datasetsQuery.isLoading ? <ActivityIndicator color="#38bdf8" /> : null}
+        {datasets.map((dataset) => (
+          <View key={dataset.id} style={styles.assetItem}>
+            <View style={{ flex: 1 }}>
+              <Text style={styles.assetTitle}>{dataset.name ?? dataset.id}</Text>
+              <Text style={styles.assetSubtitle}>Provider {truncateAddress(dataset.owner)}</Text>
+              <Text style={styles.assetMeta}>{dataset.description ?? '—'}</Text>
+              <Text style={styles.assetMeta}>Size {formatBytes(dataset.size_bytes ?? 0)}</Text>
+            </View>
+            <Tag label="Dataset" tone="neutral" />
+          </View>
+        ))}
+      </Card>
+
+      <Card title="Inference activity" subtitle="Recent jobs routed through the IPPAN inference mesh.">
+        {INFERENCE_JOBS.map((job) => (
+          <View key={job.id} style={styles.inferenceItem}>
+            <View style={{ flex: 1 }}>
+              <Text style={styles.assetTitle}>{job.model}</Text>
+              <Text style={styles.assetSubtitle}>Requester {truncateAddress(job.requester)}</Text>
+              <Text style={styles.assetMeta}>{formatDateTime(job.timestamp)}</Text>
+            </View>
+            <View style={{ alignItems: 'flex-end' }}>
+              <Tag label={job.status === 'completed' ? 'Completed' : 'Running'} tone={job.status === 'completed' ? 'success' : 'warning'} />
+              <Text style={styles.assetMeta}>{formatNumber(job.tokens)} tokens</Text>
+              <Text style={styles.assetMeta}>{job.latencyMs} ms</Text>
+            </View>
+          </View>
+        ))}
+      </Card>
+
+      <Card title="Bid marketplace" subtitle="Live bidding rounds for training and inference workloads.">
+        {BID_MARKET.map((bid) => (
+          <View key={bid.id} style={styles.inferenceItem}>
+            <View style={{ flex: 1 }}>
+              <Text style={styles.assetTitle}>{bid.dataset}</Text>
+              <Text style={styles.assetSubtitle}>Bidder {bid.bidder}</Text>
+              <Text style={styles.assetMeta}>Amount {formatNumber(bid.amount)} IPN</Text>
+            </View>
+            <Tag label={bid.status === 'leader' ? 'Leader' : 'Pending'} tone={bid.status === 'leader' ? 'success' : 'warning'} />
+          </View>
+        ))}
+      </Card>
+
+      <Card title="Proofs & attestations" subtitle="Cryptographic evidence for executions in the network.">
+        {PROOF_EVENTS.map((event) => (
+          <View key={event.id} style={styles.inferenceItem}>
+            <View style={{ flex: 1 }}>
+              <Text style={styles.assetTitle}>{event.model}</Text>
+              <Text style={styles.assetSubtitle}>{event.type}</Text>
+              <Text style={styles.assetMeta}>{formatDateTime(event.timestamp)}</Text>
+            </View>
+            <Tag label={event.status === 'verified' ? 'Verified' : 'Pending'} tone={event.status === 'verified' ? 'success' : 'warning'} />
+          </View>
+        ))}
+      </Card>
+    </ScrollView>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: '#0f172a'
+  },
+  content: {
+    padding: 20,
+    paddingBottom: 120
+  },
+  heading: {
+    fontSize: 28,
+    fontWeight: '700',
+    color: '#f8fafc',
+    marginBottom: 4
+  },
+  subheading: {
+    fontSize: 15,
+    color: '#94a3b8',
+    marginBottom: 20
+  },
+  assetItem: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    gap: 12,
+    backgroundColor: '#0b1220',
+    borderRadius: 12,
+    paddingHorizontal: 16,
+    paddingVertical: 12,
+    marginBottom: 12
+  },
+  assetTitle: {
+    color: '#f8fafc',
+    fontWeight: '600',
+    fontSize: 15
+  },
+  assetSubtitle: {
+    color: '#94a3b8',
+    fontSize: 13,
+    marginTop: 2
+  },
+  assetMeta: {
+    color: '#64748b',
+    fontSize: 12,
+    marginTop: 2
+  },
+  inferenceItem: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    backgroundColor: '#0b1220',
+    borderRadius: 12,
+    paddingHorizontal: 16,
+    paddingVertical: 12,
+    marginBottom: 12
+  }
+});

--- a/apps/mobile/src/screens/nodes/NodeManagementScreen.tsx
+++ b/apps/mobile/src/screens/nodes/NodeManagementScreen.tsx
@@ -1,0 +1,220 @@
+import React, { useEffect, useMemo, useState } from 'react';
+import { ActivityIndicator, Alert, ScrollView, StyleSheet, Text, TextInput, View } from 'react-native';
+import { useQuery } from '@tanstack/react-query';
+
+import { Card } from '../../components/Card';
+import { Button } from '../../components/Button';
+import { Tag } from '../../components/Tag';
+import { InfoRow } from '../../components/InfoRow';
+import { useApi } from '../../providers/ApiProvider';
+import { fetchHealth, fetchNodeStatus } from '../../api';
+import { defaultNodes } from '../../data/nodes';
+import { formatDateTime, formatNumber } from '../../utils/format';
+
+export default function NodeManagementScreen() {
+  const { baseUrl, setBaseUrl, client } = useApi();
+  const [draftUrl, setDraftUrl] = useState(baseUrl);
+
+  useEffect(() => {
+    setDraftUrl(baseUrl);
+  }, [baseUrl]);
+
+  const healthQuery = useQuery({
+    queryKey: ['health', baseUrl],
+    queryFn: () => fetchHealth(client),
+    staleTime: 30_000
+  });
+
+  const nodeStatusQuery = useQuery({
+    queryKey: ['node-status-summary', baseUrl],
+    queryFn: () => fetchNodeStatus(client),
+    staleTime: 30_000
+  });
+
+  const connectionTag = useMemo(() => {
+    if (healthQuery.isError || nodeStatusQuery.isError) {
+      return <Tag label="Offline" tone="danger" />;
+    }
+    if (healthQuery.data?.status === 'ok' || nodeStatusQuery.data?.node?.is_running) {
+      return <Tag label="Online" tone="success" />;
+    }
+    if (healthQuery.isLoading || nodeStatusQuery.isLoading) {
+      return <Tag label="Checking" tone="info" />;
+    }
+    return <Tag label="Unknown" tone="neutral" />;
+  }, [healthQuery.data, healthQuery.isError, healthQuery.isLoading, nodeStatusQuery.data, nodeStatusQuery.isError, nodeStatusQuery.isLoading]);
+
+  const applyBaseUrl = () => {
+    if (!draftUrl.trim()) {
+      Alert.alert('Invalid URL', 'Provide the base URL of an IPPAN validator or gateway.');
+      return;
+    }
+    setBaseUrl(draftUrl);
+  };
+
+  const handleSelectNode = (url: string) => {
+    setBaseUrl(url);
+  };
+
+  return (
+    <ScrollView style={styles.container} contentContainerStyle={styles.content}>
+      <Text style={styles.heading}>Node management</Text>
+      <Text style={styles.subheading}>
+        Pick the default validator or gateway for API calls, view health checks and latency hints for community nodes.
+      </Text>
+
+      <Card title="Active endpoint" subtitle="All mobile requests use this base URL." action={connectionTag}>
+        <Text style={styles.label}>Current base URL</Text>
+        <View style={styles.urlBox}>
+          <Text style={styles.urlText}>{baseUrl}</Text>
+        </View>
+
+        <Text style={styles.label}>Override URL</Text>
+        <TextInput
+          value={draftUrl}
+          onChangeText={setDraftUrl}
+          placeholder="https://validator.your-node:8080"
+          placeholderTextColor="#475569"
+          style={styles.input}
+          autoCapitalize="none"
+          autoCorrect={false}
+        />
+        <Button label="Apply" onPress={applyBaseUrl} />
+      </Card>
+
+      <Card title="Health" subtitle="Status derived from the node /health endpoint.">
+        {healthQuery.isLoading ? (
+          <ActivityIndicator color="#38bdf8" />
+        ) : healthQuery.isError ? (
+          <Text style={styles.placeholder}>The selected node did not respond to health checks.</Text>
+        ) : (
+          <>
+            <InfoRow label="Status" value={healthQuery.data?.status ?? '—'} />
+            <InfoRow
+              label="Last heartbeat"
+              value={healthQuery.data?.timestamp ? formatDateTime(healthQuery.data.timestamp) : '—'}
+            />
+            <InfoRow label="Network" value={healthQuery.data?.network ?? '—'} />
+          </>
+        )}
+      </Card>
+
+      <Card title="Node snapshot" subtitle="High level metrics from the status endpoint.">
+        {nodeStatusQuery.isLoading ? (
+          <ActivityIndicator color="#38bdf8" />
+        ) : nodeStatusQuery.isError ? (
+          <Text style={styles.placeholder}>Unable to fetch node statistics.</Text>
+        ) : (
+          <>
+            <InfoRow label="Node ID" value={nodeStatusQuery.data?.node?.node_id ?? nodeStatusQuery.data?.node_id ?? '—'} />
+            <InfoRow label="Peers" value={nodeStatusQuery.data?.network?.connected_peers ?? '—'} />
+            <InfoRow
+              label="Block height"
+              value={nodeStatusQuery.data?.blockchain?.current_height ?? nodeStatusQuery.data?.current_block ?? '—'}
+            />
+            <InfoRow
+              label="Transactions"
+              value={nodeStatusQuery.data?.blockchain?.total_transactions ?? nodeStatusQuery.data?.total_transactions ?? '—'}
+            />
+          </>
+        )}
+      </Card>
+
+      <Card title="Recommended endpoints" subtitle="Validator and gateway options curated by the IPPAN team.">
+        {defaultNodes.map((node) => (
+          <View key={node.id} style={styles.nodeOption}>
+            <View style={{ flex: 1 }}>
+              <Text style={styles.nodeTitle}>{node.label}</Text>
+              <Text style={styles.nodeUrl}>{node.baseUrl}</Text>
+              <Text style={styles.nodeMeta}>
+                {node.region} · {formatNumber(node.latencyMs)} ms latency {node.isCommunity ? '· Community operated' : ''}
+              </Text>
+            </View>
+            <Button label="Use" onPress={() => handleSelectNode(node.baseUrl)} />
+          </View>
+        ))}
+      </Card>
+    </ScrollView>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: '#0f172a'
+  },
+  content: {
+    padding: 20,
+    paddingBottom: 120
+  },
+  heading: {
+    fontSize: 28,
+    fontWeight: '700',
+    color: '#f8fafc',
+    marginBottom: 4
+  },
+  subheading: {
+    fontSize: 15,
+    color: '#94a3b8',
+    marginBottom: 20
+  },
+  label: {
+    color: '#cbd5f5',
+    fontSize: 13,
+    marginTop: 8,
+    marginBottom: 8
+  },
+  urlBox: {
+    backgroundColor: '#0b1220',
+    borderRadius: 12,
+    paddingHorizontal: 16,
+    paddingVertical: 12,
+    borderWidth: 1,
+    borderColor: '#1f2a44'
+  },
+  urlText: {
+    color: '#f8fafc',
+    fontSize: 14
+  },
+  input: {
+    backgroundColor: '#0b1220',
+    borderRadius: 12,
+    borderWidth: 1,
+    borderColor: '#1f2a44',
+    paddingHorizontal: 14,
+    paddingVertical: 12,
+    color: '#f8fafc',
+    fontSize: 15,
+    marginBottom: 12
+  },
+  placeholder: {
+    color: '#64748b',
+    fontSize: 14
+  },
+  nodeOption: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    gap: 12,
+    backgroundColor: '#0b1220',
+    borderRadius: 12,
+    paddingHorizontal: 16,
+    paddingVertical: 12,
+    marginBottom: 12
+  },
+  nodeTitle: {
+    color: '#f8fafc',
+    fontWeight: '600',
+    fontSize: 15
+  },
+  nodeUrl: {
+    color: '#94a3b8',
+    fontSize: 13,
+    marginTop: 2
+  },
+  nodeMeta: {
+    color: '#64748b',
+    fontSize: 12,
+    marginTop: 4
+  }
+});

--- a/apps/mobile/src/screens/wallet/WalletOverviewScreen.tsx
+++ b/apps/mobile/src/screens/wallet/WalletOverviewScreen.tsx
@@ -1,0 +1,587 @@
+import React, { useEffect, useMemo, useState } from 'react';
+import {
+  ActivityIndicator,
+  Alert,
+  ScrollView,
+  StyleSheet,
+  Text,
+  TextInput,
+  View
+} from 'react-native';
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+
+import { Card } from '../../components/Card';
+import { Button } from '../../components/Button';
+import { InfoRow } from '../../components/InfoRow';
+import { Tag } from '../../components/Tag';
+import { useApi } from '../../providers/ApiProvider';
+import { useWallet } from '../../providers/WalletProvider';
+import {
+  fetchWalletBalance,
+  fetchWalletTransactions,
+  submitPayment,
+  fetchDomains,
+  type WalletTransaction,
+  type DomainRecord,
+  type SubmitPaymentInput,
+  type SubmitPaymentResponse
+} from '../../api';
+import {
+  mockDomainUpdates,
+  mockDnsUpdates,
+  mockTldUpdates
+} from '../../data/domainUpdates';
+import {
+  formatDateTime,
+  formatNumber,
+  formatPercent,
+  truncateAddress
+} from '../../utils/format';
+
+const STORAGE_SAMPLE = {
+  reservedGb: 50,
+  usedGb: 22.5,
+  replication: 3,
+  uptimePct: 99.9,
+  bandwidthUsedGb: 48,
+  pinnedCount: 87
+};
+
+const AVAILABILITY_SAMPLE = [
+  { node: 'validator-eu-1', availability: 99.92, region: 'Frankfurt' },
+  { node: 'validator-us-1', availability: 99.87, region: 'Ashburn' },
+  { node: 'gateway-apac', availability: 99.71, region: 'Singapore' }
+];
+
+const ADDRESS_PLACEHOLDER = 'i0000000000000000000000000000000000000000000000000000000000000000';
+
+export default function WalletOverviewScreen() {
+  const { client } = useApi();
+  const queryClient = useQueryClient();
+  const {
+    walletAddress,
+    walletType,
+    setWatchAddress,
+    connectLocalWallet,
+    disconnectWallet,
+    signMessage
+  } = useWallet();
+
+  const [addressInput, setAddressInput] = useState(walletAddress ?? '');
+  const [recipient, setRecipient] = useState('');
+  const [amount, setAmount] = useState('');
+  const [memo, setMemo] = useState('');
+  const [isSettingAddress, setIsSettingAddress] = useState(false);
+
+  useEffect(() => {
+    setAddressInput(walletAddress ?? '');
+  }, [walletAddress]);
+
+  const walletEnabled = Boolean(walletAddress);
+
+  const balanceQuery = useQuery({
+    queryKey: ['wallet-balance', walletAddress],
+    queryFn: () => fetchWalletBalance(client, walletAddress as string),
+    enabled: walletEnabled,
+    staleTime: 30_000
+  });
+
+  const transactionsQuery = useQuery({
+    queryKey: ['wallet-transactions', walletAddress],
+    queryFn: () => fetchWalletTransactions(client, walletAddress as string),
+    enabled: walletEnabled,
+    staleTime: 30_000
+  });
+
+  const domainsQuery = useQuery({
+    queryKey: ['domains'],
+    queryFn: () => fetchDomains(client),
+    staleTime: 60_000
+  });
+
+  const paymentMutation = useMutation<SubmitPaymentResponse, Error, SubmitPaymentInput>({
+    mutationFn: (payload) => submitPayment(client, payload),
+    onSuccess: (result) => {
+      if (result.success) {
+        Alert.alert('Transaction submitted', result.txId ? `Tx hash: ${result.txId}` : 'The network accepted your transaction.');
+        setAmount('');
+        setRecipient('');
+        setMemo('');
+        queryClient.invalidateQueries({ queryKey: ['wallet-balance'] });
+        queryClient.invalidateQueries({ queryKey: ['wallet-transactions'] });
+      } else {
+        Alert.alert('Unable to submit transaction', result.message || 'Unknown error');
+      }
+    },
+    onError: (error: unknown) => {
+      const message = error instanceof Error ? error.message : 'Unknown error';
+      Alert.alert('Transaction failed', message);
+    }
+  });
+
+  const assets = useMemo(() => {
+    if (!balanceQuery.data) {
+      return [] as { symbol: string; name: string; balance: number }[];
+    }
+    return [
+      { symbol: 'IPN', name: 'IPPAN', balance: balanceQuery.data.balance },
+      { symbol: 'STAKE', name: 'Staked IPN', balance: balanceQuery.data.staked }
+    ];
+  }, [balanceQuery.data]);
+
+  const activities: WalletTransaction[] = useMemo(() => {
+    return (transactionsQuery.data ?? []).slice(0, 6);
+  }, [transactionsQuery.data]);
+
+  const handleSetWatchAddress = async () => {
+    try {
+      setIsSettingAddress(true);
+      await setWatchAddress(addressInput);
+      Alert.alert('Wallet updated', 'Now tracking the provided address.');
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'Unable to set address';
+      Alert.alert('Invalid address', message);
+    } finally {
+      setIsSettingAddress(false);
+    }
+  };
+
+  const handleConnectLocal = async () => {
+    try {
+      const addr = await connectLocalWallet();
+      Alert.alert('Local wallet ready', `Generated address ${truncateAddress(addr, 10)}.`);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'Unable to create wallet';
+      Alert.alert('Wallet error', message);
+    }
+  };
+
+  const handleDisconnect = async () => {
+    await disconnectWallet();
+    Alert.alert('Wallet disconnected', 'This device is no longer linked to an IPPAN wallet.');
+  };
+
+  const handleSendPayment = async () => {
+    if (!walletAddress) {
+      Alert.alert('No wallet', 'Connect or watch a wallet before sending payments.');
+      return;
+    }
+    const value = Number(amount);
+    if (!Number.isFinite(value) || value <= 0) {
+      Alert.alert('Invalid amount', 'Enter the amount to send in IPN.');
+      return;
+    }
+    if (!recipient || recipient.length < 10) {
+      Alert.alert('Recipient required', 'Enter a valid destination address.');
+      return;
+    }
+
+    const fee = Math.max(0.01, Number((value * 0.002).toFixed(4)));
+    const nonce = (balanceQuery.data?.nonce ?? 0) + 1;
+
+    try {
+      const signature = await signMessage(`${walletAddress}:${recipient}:${value}:${nonce}:${memo}`);
+      paymentMutation.mutate({
+        from: walletAddress,
+        to: recipient,
+        amount: value,
+        fee,
+        nonce,
+        memo: memo || undefined,
+        signature
+      });
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'This wallet cannot sign messages.';
+      Alert.alert('Cannot sign transaction', message);
+    }
+  };
+
+  return (
+    <ScrollView style={styles.container} contentContainerStyle={styles.content}>
+      <Text style={styles.heading}>IPPAN Wallet & Finance</Text>
+      <Text style={styles.subheading}>Manage balances, payments, domains and storage from a single mobile dashboard.</Text>
+
+      <Card
+        title="Wallet status"
+        subtitle="Link a watch-only address or promote this device to a local signer."
+        action={<Tag label={walletEnabled ? 'Connected' : 'Not connected'} tone={walletEnabled ? 'success' : 'warning'} />}
+      >
+        <InfoRow label="Wallet mode" value={walletType === 'local' ? 'Local signer' : 'Watch only'} />
+        <InfoRow
+          label="Address"
+          value={
+            <Text style={styles.addressText} selectable>
+              {walletAddress ? walletAddress : '—'}
+            </Text>
+          }
+          align="top"
+        />
+
+        <View style={styles.inputRow}>
+          <TextInput
+            value={addressInput}
+            onChangeText={setAddressInput}
+            placeholder={ADDRESS_PLACEHOLDER}
+            placeholderTextColor="#475569"
+            style={styles.input}
+            autoCapitalize="none"
+            autoCorrect={false}
+          />
+        </View>
+
+        <View style={styles.buttonRow}>
+          <Button
+            label="Set watch address"
+            onPress={handleSetWatchAddress}
+            disabled={isSettingAddress || !addressInput}
+          />
+          <Button label="Create local" onPress={handleConnectLocal} variant="secondary" />
+          <Button label="Disconnect" onPress={handleDisconnect} variant="ghost" disabled={!walletEnabled} />
+        </View>
+      </Card>
+
+      <Card title="Balances" subtitle="Realtime balances retrieved from the connected IPPAN node.">
+        {balanceQuery.isFetching ? (
+          <ActivityIndicator color="#38bdf8" />
+        ) : (
+          <View style={styles.assetList}>
+            {assets.map((asset) => (
+              <View key={asset.symbol} style={styles.assetItem}>
+                <View>
+                  <Text style={styles.assetSymbol}>{asset.symbol}</Text>
+                  <Text style={styles.assetName}>{asset.name}</Text>
+                </View>
+                <Text style={styles.assetBalance}>{formatNumber(asset.balance)}</Text>
+              </View>
+            ))}
+            {assets.length === 0 ? <Text style={styles.placeholder}>Connect a wallet to view balances.</Text> : null}
+          </View>
+        )}
+        <InfoRow label="Nonce" value={balanceQuery.data?.nonce ?? '—'} />
+        <InfoRow label="Pending" value={balanceQuery.data?.pendingTransactions?.length ?? 0} />
+      </Card>
+
+      <Card title="Payments & machine-to-machine settlement">
+        <Text style={styles.label}>Recipient address</Text>
+        <TextInput
+          value={recipient}
+          onChangeText={setRecipient}
+          placeholder="i..."
+          placeholderTextColor="#475569"
+          style={styles.input}
+          autoCapitalize="none"
+          autoCorrect={false}
+        />
+        <Text style={styles.label}>Amount (IPN)</Text>
+        <TextInput
+          value={amount}
+          onChangeText={setAmount}
+          placeholder="10.5"
+          placeholderTextColor="#475569"
+          keyboardType="decimal-pad"
+          style={styles.input}
+        />
+        <Text style={styles.label}>Memo (optional)</Text>
+        <TextInput
+          value={memo}
+          onChangeText={setMemo}
+          placeholder="Payment description"
+          placeholderTextColor="#475569"
+          style={[styles.input, styles.textArea]}
+          multiline
+          numberOfLines={3}
+        />
+        <Button
+          label={paymentMutation.isPending ? 'Submitting…' : 'Submit payment'}
+          onPress={handleSendPayment}
+          disabled={paymentMutation.isPending}
+        />
+      </Card>
+
+      <Card title="Recent activity" subtitle="Latest confirmed transactions for this wallet.">
+        {transactionsQuery.isFetching ? (
+          <ActivityIndicator color="#38bdf8" />
+        ) : activities.length === 0 ? (
+          <Text style={styles.placeholder}>No transactions yet.</Text>
+        ) : (
+          activities.map((activity) => (
+            <View key={activity.id} style={styles.transactionItem}>
+              <View style={{ flex: 1 }}>
+                <Text style={styles.transactionTitle}>{activity.type ?? 'Transfer'}</Text>
+                <Text style={styles.transactionSubtitle}>To {truncateAddress(activity.to)}</Text>
+                <Text style={styles.transactionMeta}>{formatDateTime(activity.timestamp)}</Text>
+              </View>
+              <View style={{ alignItems: 'flex-end' }}>
+                <Text style={styles.transactionAmount}>{formatNumber(activity.amount)}</Text>
+                {activity.fee ? <Text style={styles.transactionFee}>Fee {formatNumber(activity.fee)}</Text> : null}
+              </View>
+            </View>
+          ))
+        )}
+      </Card>
+
+      <Card title="Domain management" subtitle="Track owned namespaces and recent registry updates.">
+        {domainsQuery.isFetching ? (
+          <ActivityIndicator color="#38bdf8" />
+        ) : domainsQuery.data && domainsQuery.data.length > 0 ? (
+          domainsQuery.data.slice(0, 4).map((domain: DomainRecord) => (
+            <View key={domain.name || domain.domain} style={styles.domainItem}>
+              <Text style={styles.domainName}>{domain.name || domain.domain}</Text>
+              <Text style={styles.domainMeta}>
+                Owner {truncateAddress(domain.owner || walletAddress || '—')} · Expires{' '}
+                {domain.expires_at ? new Date(domain.expires_at).toLocaleDateString() : 'unknown'}
+              </Text>
+            </View>
+          ))
+        ) : (
+          <Text style={styles.placeholder}>No domains found for this wallet.</Text>
+        )}
+
+        <Text style={styles.sectionHeading}>Registry updates</Text>
+        {mockDomainUpdates.map((item) => (
+          <View key={item.id} style={styles.updateItem}>
+            <View style={{ flex: 1 }}>
+              <Text style={styles.updateTitle}>{item.domain}</Text>
+              <Text style={styles.updateDescription}>{item.description}</Text>
+              <Text style={styles.updateMeta}>{formatDateTime(item.timestamp)}</Text>
+            </View>
+            <Tag
+              label={item.status === 'completed' ? 'Completed' : item.status === 'pending' ? 'Pending' : 'Failed'}
+              tone={item.status === 'completed' ? 'success' : item.status === 'pending' ? 'warning' : 'danger'}
+            />
+          </View>
+        ))}
+      </Card>
+
+      <Card title="DNS updates" subtitle="Recent resolver adjustments propagated to IPPAN edge nodes.">
+        {mockDnsUpdates.map((item) => (
+          <View key={item.id} style={styles.updateItem}>
+            <View style={{ flex: 1 }}>
+              <Text style={styles.updateTitle}>{item.domain}</Text>
+              <Text style={styles.updateDescription}>
+                {item.recordType} · {item.recordName} → {item.newValue}
+              </Text>
+              <Text style={styles.updateMeta}>{formatDateTime(item.timestamp)}</Text>
+            </View>
+            <Tag
+              label={item.status === 'completed' ? 'Applied' : item.status === 'pending' ? 'Pending' : 'Failed'}
+              tone={item.status === 'completed' ? 'success' : item.status === 'pending' ? 'warning' : 'danger'}
+            />
+          </View>
+        ))}
+      </Card>
+
+      <Card title="Storage & availability" subtitle="Plan limits and decentralised storage footprint.">
+        <InfoRow label="Reserved" value={`${STORAGE_SAMPLE.reservedGb} GB`} />
+        <InfoRow label="Used" value={`${STORAGE_SAMPLE.usedGb} GB`} />
+        <InfoRow label="Replication" value={`${STORAGE_SAMPLE.replication}x`} />
+        <InfoRow label="Pinned files" value={STORAGE_SAMPLE.pinnedCount} />
+        <InfoRow label="Bandwidth used" value={`${STORAGE_SAMPLE.bandwidthUsedGb} GB`} />
+        <InfoRow label="Uptime" value={formatPercent(STORAGE_SAMPLE.uptimePct)} />
+
+        <Text style={styles.sectionHeading}>Node availability</Text>
+        {AVAILABILITY_SAMPLE.map((item) => (
+          <View key={item.node} style={styles.availabilityItem}>
+            <View>
+              <Text style={styles.updateTitle}>{item.node}</Text>
+              <Text style={styles.updateMeta}>{item.region}</Text>
+            </View>
+            <Text style={styles.transactionAmount}>{formatPercent(item.availability)}</Text>
+          </View>
+        ))}
+      </Card>
+
+      <Card title="TLD insights" subtitle="Changes to premium namespaces and governance notices.">
+        {mockTldUpdates.map((item) => (
+          <View key={item.id} style={styles.updateItem}>
+            <View style={{ flex: 1 }}>
+              <Text style={styles.updateTitle}>{item.tld}</Text>
+              <Text style={styles.updateDescription}>{item.description}</Text>
+              <Text style={styles.updateMeta}>{formatDateTime(item.timestamp)}</Text>
+            </View>
+            <Tag label={item.status === 'active' ? 'Active' : 'Inactive'} tone={item.status === 'active' ? 'info' : 'neutral'} />
+          </View>
+        ))}
+      </Card>
+    </ScrollView>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: '#0f172a'
+  },
+  content: {
+    padding: 20,
+    paddingBottom: 120
+  },
+  heading: {
+    fontSize: 28,
+    fontWeight: '700',
+    color: '#f8fafc',
+    marginBottom: 4
+  },
+  subheading: {
+    fontSize: 15,
+    color: '#94a3b8',
+    marginBottom: 20
+  },
+  addressText: {
+    fontSize: 13,
+    color: '#e2e8f0',
+    fontFamily: 'Courier'
+  },
+  inputRow: {
+    marginTop: 6,
+    marginBottom: 12
+  },
+  input: {
+    backgroundColor: '#0b1220',
+    borderRadius: 12,
+    borderWidth: 1,
+    borderColor: '#1f2a44',
+    paddingHorizontal: 14,
+    paddingVertical: 12,
+    color: '#f8fafc',
+    fontSize: 15
+  },
+  textArea: {
+    minHeight: 96,
+    textAlignVertical: 'top'
+  },
+  buttonRow: {
+    flexDirection: 'row',
+    gap: 10,
+    flexWrap: 'wrap'
+  },
+  assetList: {
+    gap: 12
+  },
+  assetItem: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    backgroundColor: '#0b1220',
+    borderRadius: 12,
+    paddingHorizontal: 16,
+    paddingVertical: 12
+  },
+  assetSymbol: {
+    color: '#f8fafc',
+    fontSize: 16,
+    fontWeight: '700'
+  },
+  assetName: {
+    color: '#94a3b8',
+    fontSize: 13
+  },
+  assetBalance: {
+    color: '#38bdf8',
+    fontSize: 17,
+    fontWeight: '700'
+  },
+  placeholder: {
+    color: '#64748b',
+    fontSize: 14
+  },
+  label: {
+    color: '#cbd5f5',
+    fontSize: 13,
+    marginBottom: 6,
+    marginTop: 6
+  },
+  transactionItem: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    backgroundColor: '#0b1220',
+    borderRadius: 12,
+    paddingHorizontal: 14,
+    paddingVertical: 12,
+    marginBottom: 12
+  },
+  transactionTitle: {
+    color: '#f8fafc',
+    fontWeight: '600',
+    fontSize: 15
+  },
+  transactionSubtitle: {
+    color: '#94a3b8',
+    fontSize: 13
+  },
+  transactionMeta: {
+    color: '#64748b',
+    fontSize: 12,
+    marginTop: 4
+  },
+  transactionAmount: {
+    color: '#38bdf8',
+    fontWeight: '700',
+    fontSize: 16
+  },
+  transactionFee: {
+    color: '#94a3b8',
+    fontSize: 12
+  },
+  domainItem: {
+    backgroundColor: '#0b1220',
+    borderRadius: 12,
+    paddingHorizontal: 14,
+    paddingVertical: 12,
+    marginBottom: 12
+  },
+  domainName: {
+    color: '#f8fafc',
+    fontSize: 15,
+    fontWeight: '600'
+  },
+  domainMeta: {
+    color: '#64748b',
+    fontSize: 12,
+    marginTop: 4
+  },
+  sectionHeading: {
+    color: '#cbd5f5',
+    fontSize: 14,
+    fontWeight: '600',
+    marginTop: 12,
+    marginBottom: 8
+  },
+  updateItem: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    gap: 12,
+    backgroundColor: '#0b1220',
+    borderRadius: 12,
+    paddingHorizontal: 14,
+    paddingVertical: 12,
+    marginBottom: 10
+  },
+  updateTitle: {
+    color: '#f8fafc',
+    fontWeight: '600',
+    fontSize: 15
+  },
+  updateDescription: {
+    color: '#94a3b8',
+    fontSize: 13,
+    marginTop: 2
+  },
+  updateMeta: {
+    color: '#64748b',
+    fontSize: 12,
+    marginTop: 4
+  },
+  availabilityItem: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    backgroundColor: '#0b1220',
+    borderRadius: 12,
+    paddingHorizontal: 16,
+    paddingVertical: 12,
+    marginBottom: 10
+  }
+});

--- a/apps/mobile/src/utils/format.ts
+++ b/apps/mobile/src/utils/format.ts
@@ -1,0 +1,63 @@
+export function formatNumber(value: number | null | undefined, options: Intl.NumberFormatOptions = {}): string {
+  if (value === null || value === undefined || Number.isNaN(value)) {
+    return '—';
+  }
+  return new Intl.NumberFormat('en-US', {
+    maximumFractionDigits: value < 1 ? 4 : 2,
+    minimumFractionDigits: value < 1 ? 2 : 0,
+    ...options
+  }).format(value);
+}
+
+export function formatCurrency(value: number | null | undefined, currency = 'USD'): string {
+  if (value === null || value === undefined || Number.isNaN(value)) {
+    return '—';
+  }
+  return new Intl.NumberFormat('en-US', {
+    style: 'currency',
+    currency,
+    maximumFractionDigits: 2
+  }).format(value);
+}
+
+export function formatBytes(bytes: number | null | undefined): string {
+  if (bytes === null || bytes === undefined || Number.isNaN(bytes)) {
+    return '—';
+  }
+  if (bytes === 0) {
+    return '0 B';
+  }
+  const k = 1024;
+  const units = ['B', 'KB', 'MB', 'GB', 'TB'];
+  const i = Math.floor(Math.log(bytes) / Math.log(k));
+  const size = bytes / Math.pow(k, i);
+  return `${size.toFixed(size >= 10 || i === 0 ? 0 : 1)} ${units[i]}`;
+}
+
+export function formatDateTime(input: string | number | Date | null | undefined): string {
+  if (!input) {
+    return '—';
+  }
+  const date = input instanceof Date ? input : new Date(input);
+  if (Number.isNaN(date.getTime())) {
+    return '—';
+  }
+  return `${date.toLocaleDateString()} ${date.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })}`;
+}
+
+export function truncateAddress(address: string | null | undefined, size = 6): string {
+  if (!address) {
+    return '—';
+  }
+  if (address.length <= size * 2) {
+    return address;
+  }
+  return `${address.slice(0, size)}…${address.slice(-size)}`;
+}
+
+export function formatPercent(value: number | null | undefined, fractionDigits = 1): string {
+  if (value === null || value === undefined || Number.isNaN(value)) {
+    return '—';
+  }
+  return `${value.toFixed(fractionDigits)}%`;
+}

--- a/apps/mobile/tsconfig.json
+++ b/apps/mobile/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "extends": "expo/tsconfig.base",
+  "compilerOptions": {
+    "strict": true,
+    "baseUrl": ".",
+    "paths": {
+      "~/*": ["src/*"]
+    }
+  },
+  "include": ["**/*.ts", "**/*.tsx", "App.tsx"],
+  "exclude": ["node_modules", "babel.config.js", "metro.config.js"]
+}


### PR DESCRIPTION
## Summary
- introduce a new Expo-managed mobile client under `apps/mobile` with bottom-tab navigation covering wallet, explorer, neural, and node management workflows
- implement reusable UI primitives, API helpers, and context providers so mobile shares behaviour with the existing unified web UI, including wallet persistence and configurable node endpoints
- document setup, linting, and runtime instructions for building and running the Android/iOS application

## Testing
- npm run lint
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68d41d8953cc832baf882e48db50543c