### PR TITLE
Improve networking and RPC for production deployment

### DIFF
--- a/crates/consensus/src/lib.rs
+++ b/crates/consensus/src/lib.rs
@@ -99,6 +99,11 @@ impl PoAConsensus {
         self.tx_sender.clone()
     }
 
+    /// Get a handle to the current mempool
+    pub fn mempool(&self) -> Arc<RwLock<Vec<Transaction>>> {
+        self.mempool.clone()
+    }
+
     /// Start the consensus engine
     pub async fn start(&mut self) -> Result<()> {
         *self.is_running.write() = true;

--- a/crates/rpc/Cargo.toml
+++ b/crates/rpc/Cargo.toml
@@ -24,6 +24,7 @@ axum = { workspace = true }
 tower = { workspace = true }
 tower-http = { workspace = true }
 futures = { workspace = true }
+parking_lot = { workspace = true }
 
 [dev-dependencies]
 ed25519-dalek = { workspace = true }

--- a/crates/types/Cargo.toml
+++ b/crates/types/Cargo.toml
@@ -19,3 +19,4 @@ time = { workspace = true }
 once_cell = { workspace = true }
 parking_lot = { workspace = true }
 ed25519-dalek = { workspace = true }
+thiserror = { workspace = true }

--- a/crates/types/src/lib.rs
+++ b/crates/types/src/lib.rs
@@ -1,8 +1,10 @@
+pub mod address;
 pub mod block;
 pub mod hashtimer;
 pub mod time_service;
 pub mod transaction;
 
+pub use address::*;
 pub use block::*;
 pub use hashtimer::*;
 pub use time_service::*;

--- a/crates/types/src/transaction.rs
+++ b/crates/types/src/transaction.rs
@@ -53,7 +53,7 @@ impl Transaction {
 
     /// Recompute the transaction identifier from its contents.
     pub fn refresh_id(&mut self) {
-        self.id = self.compute_hash();
+        self.id = self.hash();
     }
 
     /// Create payload for HashTimer computation


### PR DESCRIPTION
## Summary
- overhaul the HTTP P2P network to auto-detect public reachability with UPnP, external IP lookups, and periodic peer announcements
- extend node configuration and startup to supply consensus handles and public networking metadata to the RPC layer
- enrich the RPC service with API v1 routes, balance helpers, and address parsing utilities while updating transaction handling

## Testing
- cargo test

------
https://chatgpt.com/codex/tasks/task_e_68d492d2e2d8832b9acd063e0580cd18