### PR TITLE
Replace explorer mock data with live RPC integrations

### DIFF
--- a/apps/unified-ui/src/lib/api.ts
+++ b/apps/unified-ui/src/lib/api.ts
@@ -67,6 +67,24 @@ export async function getDatasets(): Promise<Dataset[]> {
   return response.data;
 }
 
+// Accounts API
+export interface AccountSummary {
+  address: string;
+  balance: number;
+  nonce: number;
+}
+
+export async function getAccounts(): Promise<AccountSummary[]> {
+  const response = await api.get('/accounts');
+  const body = response.data;
+
+  if (body?.success && Array.isArray(body.data)) {
+    return body.data as AccountSummary[];
+  }
+
+  return [];
+}
+
 // Wallet API - Updated for real IPPAN nodes
 export interface WalletBalance {
   address: string;

--- a/apps/unified-ui/src/pages/explorer/AccountsPage.tsx
+++ b/apps/unified-ui/src/pages/explorer/AccountsPage.tsx
@@ -1,149 +1,72 @@
-import { useState, useEffect } from 'react'
+import { useEffect, useMemo, useState } from 'react'
 import { Card, Button, Badge, LoadingSpinner, Field, Input, Select, SelectTrigger, SelectValue, SelectContent, SelectItem } from '../../components/UI'
+import { AccountSummary, getAccounts } from '../../lib/api'
 
-interface Account {
-  address: string
-  balance: string
-  nonce: number
-  transactionCount: number
-  firstSeen: string
-  lastSeen: string
-  type: 'user' | 'validator'
-  stakedAmount?: string
-  validatorStatus?: 'active' | 'inactive'
+interface AccountRow extends AccountSummary {
+  transactionCount?: number
 }
 
+const formatAmount = (value: number) => new Intl.NumberFormat(undefined, {
+  minimumFractionDigits: 0,
+  maximumFractionDigits: 6,
+}).format(value)
+
 export default function AccountsPage() {
-  const [accounts, setAccounts] = useState<Account[]>([])
+  const [accounts, setAccounts] = useState<AccountRow[]>([])
   const [isLoading, setIsLoading] = useState(true)
-  const [selectedAccount, setSelectedAccount] = useState<Account | null>(null)
+  const [error, setError] = useState<string | null>(null)
   const [searchTerm, setSearchTerm] = useState('')
-  const [filterType, setFilterType] = useState<string>('all')
-  const [sortBy, setSortBy] = useState<string>('balance')
-  const [sortOrder, setSortOrder] = useState<'asc' | 'desc'>('desc')
-  const [isSearching, setIsSearching] = useState(false)
+  const [sortBy, setSortBy] = useState<'balance_desc' | 'balance_asc' | 'nonce_desc' | 'nonce_asc' | 'address'>('balance_desc')
 
   useEffect(() => {
-    const mockAccounts: Account[] = [
-      {
-        address: "i0000000000000000000000000000000000000000000000000000000000000000",
-        balance: "1000.0",
-        nonce: 42,
-        transactionCount: 156,
-        firstSeen: '2024-01-15T10:30:00Z',
-        lastSeen: new Date().toISOString(),
-        type: 'user'
-      },
-      {
-        address: "i1111111111111111111111111111111111111111111111111111111111111111",
-        balance: "2500.0",
-        nonce: 23,
-        transactionCount: 89,
-        firstSeen: '2024-02-20T14:15:00Z',
-        lastSeen: new Date(Date.now() - 3600000).toISOString(),
-        type: 'validator',
-        stakedAmount: '10,000.00 IPPAN',
-        validatorStatus: 'active'
-      },
-      {
-        address: "i2222222222222222222222222222222222222222222222222222222222222222",
-        balance: "5000.0",
-        nonce: 67,
-        transactionCount: 312,
-        firstSeen: '2024-01-05T08:20:00Z',
-        lastSeen: new Date(Date.now() - 7200000).toISOString(),
-        type: 'validator',
-        stakedAmount: '25,000.00 IPPAN',
-        validatorStatus: 'active'
-      },
-      {
-        address: "i3333333333333333333333333333333333333333333333333333333333333333",
-        balance: "750.5",
-        nonce: 12,
-        transactionCount: 45,
-        firstSeen: '2024-03-15T16:45:00Z',
-        lastSeen: new Date(Date.now() - 1800000).toISOString(),
-        type: 'user'
-      },
-      {
-        address: "i4444444444444444444444444444444444444444444444444444444444444444",
-        balance: "15000.0",
-        nonce: 34,
-        transactionCount: 189,
-        firstSeen: '2024-01-20T11:30:00Z',
-        lastSeen: new Date(Date.now() - 5400000).toISOString(),
-        type: 'validator',
-        stakedAmount: '50,000.00 IPPAN',
-        validatorStatus: 'inactive'
-      },
-      {
-        address: "i5555555555555555555555555555555555555555555555555555555555555555",
-        balance: "250.0",
-        nonce: 8,
-        transactionCount: 23,
-        firstSeen: '2024-03-20T14:15:00Z',
-        lastSeen: new Date(Date.now() - 3600000).toISOString(),
-        type: 'user'
-      },
-      {
-        address: "i6666666666666666666666666666666666666666666666666666666666666666",
-        balance: "3200.0",
-        nonce: 156,
-        transactionCount: 445,
-        firstSeen: '2024-01-10T09:30:00Z',
-        lastSeen: new Date(Date.now() - 7200000).toISOString(),
-        type: 'user'
-      },
-      {
-        address: "i7777777777777777777777777777777777777777777777777777777777777777",
-        balance: "850.0",
-        nonce: 29,
-        transactionCount: 78,
-        firstSeen: '2024-03-05T13:20:00Z',
-        lastSeen: new Date(Date.now() - 1800000).toISOString(),
-        type: 'user'
-      }
-    ]
+    const fetchAccounts = async () => {
+      setIsLoading(true)
+      setError(null)
 
-    setAccounts(mockAccounts)
-    setIsLoading(false)
+      try {
+        const list = await getAccounts()
+        setAccounts(list)
+      } catch (err: any) {
+        console.error('Failed to load accounts', err)
+        setError(err?.message || 'Unable to load accounts from the RPC service.')
+      } finally {
+        setIsLoading(false)
+      }
+    }
+
+    fetchAccounts()
   }, [])
 
-  const handleSearch = async () => {
-    setIsSearching(true)
-    // Simulate API call delay
-    await new Promise(resolve => setTimeout(resolve, 500))
-    setIsSearching(false)
-  }
+  const filteredAccounts = useMemo(() => {
+    const needle = searchTerm.trim().toLowerCase()
 
-  const filteredAndSortedAccounts = accounts
-    .filter(account => {
-      const matchesSearch = account.address.toLowerCase().includes(searchTerm.toLowerCase())
-      const matchesType = filterType === 'all' || account.type === filterType
-      return matchesSearch && matchesType
-    })
-    .sort((a, b) => {
-      let comparison = 0
-      
+    const filtered = needle
+      ? accounts.filter((account) => account.address.toLowerCase().includes(needle))
+      : accounts
+
+    const sorted = [...filtered]
+
+    sorted.sort((a, b) => {
       switch (sortBy) {
-        case 'balance':
-          comparison = parseFloat(a.balance) - parseFloat(b.balance)
-          break
-        case 'transactionCount':
-          comparison = a.transactionCount - b.transactionCount
-          break
-        case 'nonce':
-          comparison = a.nonce - b.nonce
-          break
-        case 'lastSeen':
-          comparison = new Date(a.lastSeen).getTime() - new Date(b.lastSeen).getTime()
-          break
+        case 'balance_desc':
+          return b.balance - a.balance
+        case 'balance_asc':
+          return a.balance - b.balance
+        case 'nonce_desc':
+          return b.nonce - a.nonce
+        case 'nonce_asc':
+          return a.nonce - b.nonce
+        case 'address':
+          return a.address.localeCompare(b.address)
         default:
-          comparison = 0
+          return 0
       }
-      
-      return sortOrder === 'asc' ? comparison : -comparison
     })
+
+    return sorted
+  }, [accounts, searchTerm, sortBy])
+
+  const totalSupply = accounts.reduce((acc, account) => acc + account.balance, 0)
 
   if (isLoading) {
     return (
@@ -155,249 +78,102 @@ export default function AccountsPage() {
 
   return (
     <div className="space-y-6">
-      <div className="flex justify-between items-center">
+      <div className="flex flex-col md:flex-row md:items-center md:justify-between gap-3">
         <div>
           <h1 className="text-2xl font-bold text-gray-900">Accounts</h1>
-          <p className="text-sm text-gray-600">
-            L1 IPPAN accounts (Users & Validators) • Smart contracts run on L2
-          </p>
+          <p className="text-sm text-gray-600">All accounts tracked by this node&apos;s local storage.</p>
         </div>
-        <Badge variant="success">Live Network</Badge>
+        <Badge variant="success">Live RPC</Badge>
       </div>
 
-      <Card title="🔍 Search & Filter Accounts">
-        <div className="space-y-4">
-          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4">
-            <div className="lg:col-span-2">
-              <Field label="Account Address">
-                <div className="flex gap-2">
-                  <Input
-                    placeholder="Search by address..."
-                    value={searchTerm}
-                    onChange={(e) => setSearchTerm(e.target.value)}
-                    onKeyPress={(e) => e.key === 'Enter' && handleSearch()}
-                    className="flex-1"
-                  />
-                  <Button 
-                    onClick={handleSearch}
-                    disabled={isSearching}
-                    className="px-4"
-                  >
-                    {isSearching ? '⏳' : '🔍'} Search
-                  </Button>
-                </div>
-              </Field>
-            </div>
-            
-            <div>
-              <Field label="Account Type">
-                <Select value={filterType} onValueChange={setFilterType}>
-                  <SelectTrigger>
-                    <SelectValue />
-                  </SelectTrigger>
-                  <SelectContent>
-                    <SelectItem value="all">All Types</SelectItem>
-                    <SelectItem value="user">Users</SelectItem>
-                    <SelectItem value="validator">Validators</SelectItem>
-                  </SelectContent>
-                </Select>
-              </Field>
-            </div>
-            
-            <div>
-              <Field label="Sort By">
-                <Select value={sortBy} onValueChange={setSortBy}>
-                  <SelectTrigger>
-                    <SelectValue />
-                  </SelectTrigger>
-                  <SelectContent>
-                    <SelectItem value="balance">Balance</SelectItem>
-                    <SelectItem value="transactionCount">Transactions</SelectItem>
-                    <SelectItem value="nonce">Nonce</SelectItem>
-                    <SelectItem value="lastSeen">Last Seen</SelectItem>
-                  </SelectContent>
-                </Select>
-              </Field>
-            </div>
-          </div>
-          
-          <div className="flex items-center justify-between">
-            <div className="flex items-center gap-4">
-              <div className="flex items-center gap-2">
-                <input
-                  type="radio"
-                  id="sort-asc"
-                  name="sortOrder"
-                  value="asc"
-                  checked={sortOrder === 'asc'}
-                  onChange={(e) => setSortOrder(e.target.value as 'asc' | 'desc')}
-                  className="w-4 h-4"
-                />
-                <label htmlFor="sort-asc" className="text-sm">Ascending</label>
-              </div>
-              <div className="flex items-center gap-2">
-                <input
-                  type="radio"
-                  id="sort-desc"
-                  name="sortOrder"
-                  value="desc"
-                  checked={sortOrder === 'desc'}
-                  onChange={(e) => setSortOrder(e.target.value as 'asc' | 'desc')}
-                  className="w-4 h-4"
-                />
-                <label htmlFor="sort-desc" className="text-sm">Descending</label>
-              </div>
-            </div>
-            
-            <div className="text-sm text-gray-600">
-              Showing {filteredAndSortedAccounts.length} of {accounts.length} accounts
-            </div>
-          </div>
+      <Card title="Search & Sort">
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+          <Field label="Account Address">
+            <Input
+              placeholder="Search by address…"
+              value={searchTerm}
+              onChange={(event) => setSearchTerm(event.target.value)}
+            />
+          </Field>
+
+          <Field label="Sort By">
+            <Select value={sortBy} onValueChange={(value) => setSortBy(value as typeof sortBy)}>
+              <SelectTrigger>
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="balance_desc">Balance (high → low)</SelectItem>
+                <SelectItem value="balance_asc">Balance (low → high)</SelectItem>
+                <SelectItem value="nonce_desc">Nonce (high → low)</SelectItem>
+                <SelectItem value="nonce_asc">Nonce (low → high)</SelectItem>
+                <SelectItem value="address">Address</SelectItem>
+              </SelectContent>
+            </Select>
+          </Field>
         </div>
+
+        {error && (
+          <div className="mt-3 text-sm text-red-600 bg-red-50 border border-red-200 rounded-md p-3">
+            {error}
+          </div>
+        )}
       </Card>
 
       <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
-        <div className="lg:col-span-2">
-          <Card title={`📊 Accounts (${filteredAndSortedAccounts.length})`}>
-            <div className="space-y-3">
-              {filteredAndSortedAccounts.length === 0 ? (
-                <div className="text-center text-gray-500 py-8">
-                  <div className="text-4xl mb-2">🔍</div>
-                  <div>No accounts found</div>
-                  <div className="text-sm">Try adjusting your search criteria</div>
-                </div>
-              ) : (
-                filteredAndSortedAccounts.map((account) => (
-                <div
-                  key={account.address}
-                  className={`p-4 border rounded-lg cursor-pointer transition-all hover:shadow-md ${
-                    selectedAccount?.address === account.address ? 'border-blue-500 bg-blue-50' : 'border-gray-200'
-                  }`}
-                  onClick={() => setSelectedAccount(account)}
-                >
-                  <div className="flex justify-between items-start">
-                    <div className="flex-1">
-                      <div className="flex items-center space-x-2 mb-2">
-                        <Badge variant={account.type === 'validator' ? 'success' : 'blue'}>
-                          {account.type.toUpperCase()}
-                        </Badge>
-                        {account.type === 'validator' && (
-                          <Badge variant={account.validatorStatus === 'active' ? 'success' : 'warning'}>
-                            {account.validatorStatus}
-                          </Badge>
-                        )}
-                      </div>
-                      <div className="text-sm text-gray-600 space-y-1">
-                        <div>Address: {account.address.substring(0, 16)}...</div>
-                        <div>Balance: {account.balance}</div>
-                        <div>Transactions: {account.transactionCount}</div>
-                        {account.stakedAmount && <div>Staked: {account.stakedAmount}</div>}
-                      </div>
-                    </div>
-                    <div className="text-right text-sm text-gray-600">
-                      <div>{account.balance}</div>
-                      <div>Nonce: {account.nonce}</div>
-                      <div>{new Date(account.lastSeen).toLocaleDateString()}</div>
-                    </div>
-                  </div>
-                </div>
-                ))
-              )}
+        <Card title="Summary" className="lg:col-span-1">
+          <div className="space-y-3 text-sm text-gray-700">
+            <p><strong>Total Accounts:</strong> {accounts.length}</p>
+            <p><strong>Total Balance:</strong> {formatAmount(totalSupply)} IPN</p>
+            <p><strong>Average Balance:</strong> {accounts.length ? formatAmount(totalSupply / accounts.length) : '0'} IPN</p>
+          </div>
+          <Button className="w-full mt-4" onClick={() => window.location.reload()}>Refresh</Button>
+        </Card>
+
+        <Card title={`Accounts (${filteredAccounts.length})`} className="lg:col-span-2">
+          {filteredAccounts.length === 0 ? (
+            <div className="text-center text-gray-500 py-12">
+              {searchTerm ? 'No accounts match your search.' : 'No accounts found on this node yet.'}
             </div>
-          </Card>
-        </div>
-
-        <div className="lg:col-span-1">
-          <Card title="📋 Account Details">
-            {selectedAccount ? (
-              <div className="space-y-4">
-                <div>
-                  <label className="block text-sm font-medium text-gray-700">Address</label>
-                  <div className="font-mono text-xs break-all bg-gray-100 p-2 rounded">
-                    {selectedAccount.address}
-                  </div>
-                  <Button 
-                    onClick={() => navigator.clipboard?.writeText(selectedAccount.address)}
-                    className="mt-2 text-xs px-2 py-1"
-                  >
-                    📋 Copy Address
-                  </Button>
-                </div>
-                
-                <div className="grid grid-cols-2 gap-4">
-                  <div>
-                    <label className="block text-sm font-medium text-gray-700">Balance</label>
-                    <div className="text-lg font-bold text-green-600">{selectedAccount.balance} IPPAN</div>
-                  </div>
-                  <div>
-                    <label className="block text-sm font-medium text-gray-700">Type</label>
-                    <Badge variant={selectedAccount.type === 'validator' ? 'success' : 'blue'}>
-                      {selectedAccount.type.toUpperCase()}
-                    </Badge>
-                  </div>
-                </div>
-
-                {selectedAccount.stakedAmount && (
-                  <div>
-                    <label className="block text-sm font-medium text-gray-700">Staked Amount</label>
-                    <div className="text-lg font-semibold text-blue-600">{selectedAccount.stakedAmount}</div>
-                  </div>
-                )}
-                
-                {selectedAccount.validatorStatus && (
-                  <div>
-                    <label className="block text-sm font-medium text-gray-700">Validator Status</label>
-                    <Badge variant={selectedAccount.validatorStatus === 'active' ? 'success' : 'warning'}>
-                      {selectedAccount.validatorStatus.toUpperCase()}
-                    </Badge>
-                  </div>
-                )}
-                
-                <div className="grid grid-cols-2 gap-4">
-                  <div>
-                    <label className="block text-sm font-medium text-gray-700">Nonce</label>
-                    <div className="text-lg">{selectedAccount.nonce}</div>
-                  </div>
-                  <div>
-                    <label className="block text-sm font-medium text-gray-700">Transactions</label>
-                    <div className="text-lg">{selectedAccount.transactionCount}</div>
-                  </div>
-                </div>
-                
-                <div>
-                  <label className="block text-sm font-medium text-gray-700">First Seen</label>
-                  <div className="text-sm text-gray-600">{new Date(selectedAccount.firstSeen).toLocaleString()}</div>
-                </div>
-                
-                <div>
-                  <label className="block text-sm font-medium text-gray-700">Last Seen</label>
-                  <div className="text-sm text-gray-600">{new Date(selectedAccount.lastSeen).toLocaleString()}</div>
-                </div>
-                
-                <div className="pt-4 border-t">
-                  <Button 
-                    className="w-full mb-2"
-                    onClick={() => window.open(`/explorer/transactions?address=${selectedAccount.address}`, '_blank')}
-                  >
-                    📊 View Transactions
-                  </Button>
-                  <Button 
-                    className="w-full bg-gray-600 hover:bg-gray-700"
-                    onClick={() => setSelectedAccount(null)}
-                  >
-                    ✕ Clear Selection
-                  </Button>
-                </div>
-              </div>
-            ) : (
-              <div className="text-center text-gray-500 py-8">
-                <div className="text-4xl mb-2">👆</div>
-                <div>Select an account to view details</div>
-                <div className="text-sm">Click on any account from the list</div>
-              </div>
-            )}
-          </Card>
-        </div>
+          ) : (
+            <div className="overflow-x-auto">
+              <table className="min-w-full text-sm text-left">
+                <thead>
+                  <tr className="text-gray-500 border-b">
+                    <th className="py-2 pr-4">Address</th>
+                    <th className="py-2 pr-4">Balance (IPN)</th>
+                    <th className="py-2 pr-4">Nonce</th>
+                    <th className="py-2 pr-4">Actions</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {filteredAccounts.map((account) => (
+                    <tr key={account.address} className="border-b last:border-0">
+                      <td className="py-3 pr-4 font-mono text-xs text-gray-700 break-all">{account.address}</td>
+                      <td className="py-3 pr-4">{formatAmount(account.balance)}</td>
+                      <td className="py-3 pr-4">{account.nonce}</td>
+                      <td className="py-3 pr-4">
+                        <div className="flex flex-wrap gap-2">
+                          <Button
+                            variant="ghost"
+                            onClick={() => navigator.clipboard?.writeText(account.address)}
+                          >
+                            Copy
+                          </Button>
+                          <Button
+                            variant="ghost"
+                            onClick={() => window.open(`/explorer/transactions?address=${account.address}`, '_blank')}
+                          >
+                            View Transactions
+                          </Button>
+                        </div>
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          )}
+        </Card>
       </div>
     </div>
   )

--- a/apps/unified-ui/src/pages/explorer/TransactionsPage.tsx
+++ b/apps/unified-ui/src/pages/explorer/TransactionsPage.tsx
@@ -1,613 +1,280 @@
-import { useState, useEffect } from 'react'
-import { useNavigate } from 'react-router-dom'
+import { useEffect, useMemo, useState } from 'react'
+import { useSearchParams } from 'react-router-dom'
 import { Card, Button, Badge, LoadingSpinner, Field, Input } from '../../components/UI'
+import { getWalletTransactions } from '../../lib/walletApi'
 
-// Canonical IPPAN HashTimer v1 structure matching JSON schema
-interface HashTimer {
-  version: 'v1';
-  time: {
-    t_ns: string;              // Nanoseconds since epoch (stringified big int)
-    precision_ns: number;      // Precision quantum
-    drift_ns: string;          // Clock drift (stringified signed int)
-  };
-  position: {
-    round: string;             // Consensus round (stringified big int)
-    seq: number;               // Sequence number within round
-    kind: 'Tx' | 'Block' | 'Round';
-  };
-  node_id: string;             // 16-byte node identifier (32 hex chars)
-  payload_digest: string;      // SHA-256 of event payload (64 hex chars)
-  hash_timer_digest: string;   // SHA-256 of 96-byte HashTimer buffer (64 hex chars)
-}
-
-// Canonical IPPAN Transaction structure matching JSON schema
 interface Transaction {
-  tx_hash: string;             // Transaction hash (64 hex chars)
-  from: string;                // Sender address (32 hex chars for flexibility)
-  to: string;                  // Recipient address (32 hex chars for flexibility)
-  amount: string;              // Amount (stringified big int)
-  fee: number;                 // Transaction fee
-  nonce: number;               // Transaction nonce
-  memo?: string;               // Optional memo
-  signature: string;           // Transaction signature
-  hashtimer: HashTimer;        // Canonical HashTimer v1
-  block_id?: string;           // Block containing this transaction
-  block_parents?: string[];    // Parent blocks of the containing block
-  block_parent_rounds?: string[]; // Parent rounds of the containing block
-  confidentiality?: 'public' | 'private' | 'confidential'; // Transaction privacy level
+  id: string
+  from: string
+  to: string
+  amount: number
+  nonce: number
+  timestamp: number
+  direction: 'send' | 'receive' | 'self' | 'other'
+  hashtimer: string
 }
 
-// Helper function to create canonical IPPAN HashTimer v1
-const createHashTimer = (timestamp: number, nodeId: string, round: number, sequence: number, kind: 'Tx' | 'Block' | 'Round', payloadDigest?: string): HashTimer => {
-  const timestamp_ns = timestamp * 1_000_000; // Convert to nanoseconds
-  const drift_ns = Math.floor(Math.random() * 1000) - 500; // Random drift ±500ns
-  
-  // Generate 16-byte node_id (32 hex chars)
-  const nodeIdBytes = new TextEncoder().encode(nodeId);
-  const nodeHash = sha256(nodeIdBytes);
-  const nodeIdHex = Array.from(nodeHash.slice(0, 16)).map(b => b.toString(16).padStart(2, '0')).join('');
-  
-  // Generate payload digest if not provided
-  const finalPayloadDigest = payloadDigest || Array.from({length: 64}, () => Math.floor(Math.random() * 16).toString(16)).join('');
-  
-  // Create 96-byte HashTimer input buffer (canonical encoding)
-  const buffer = new ArrayBuffer(96);
-  const view = new DataView(buffer);
-  
-  // Version tag (16 bytes)
-  const versionTag = new TextEncoder().encode("IPPAN-HT-v1____");
-  for (let i = 0; i < 16; i++) {
-    view.setUint8(i, i < versionTag.length ? versionTag[i] : 0);
-  }
-  
-  // Time (8 bytes, little-endian)
-  view.setBigUint64(16, BigInt(timestamp_ns), true);
-  
-  // Precision (4 bytes, little-endian)
-  view.setUint32(24, 100, true);
-  
-  // Drift (4 bytes, little-endian, signed)
-  view.setInt32(28, drift_ns, true);
-  
-  // Round (8 bytes, little-endian)
-  view.setBigUint64(32, BigInt(round), true);
-  
-  // Sequence (4 bytes, little-endian)
-  view.setUint32(40, sequence, true);
-  
-  // Kind (4 bytes, little-endian) - 1=Tx, 2=Block, 3=Round
-  const kindValue = kind === 'Tx' ? 1 : kind === 'Block' ? 2 : 3;
-  view.setUint32(44, kindValue, true);
-  
-  // Node ID (16 bytes)
-  const nodeIdBytes2 = new Uint8Array(16);
-  for (let i = 0; i < 16; i++) {
-    nodeIdBytes2[i] = parseInt(nodeIdHex.substr(i * 2, 2), 16);
-  }
-  for (let i = 0; i < 16; i++) {
-    view.setUint8(48 + i, nodeIdBytes2[i]);
-  }
-  
-  // Payload digest (32 bytes)
-  for (let i = 0; i < 32; i++) {
-    const byte = parseInt(finalPayloadDigest.substr(i * 2, 2), 16);
-    view.setUint8(64 + i, byte);
-  }
-  
-  // Calculate hash_timer_digest (SHA-256 of the 96-byte buffer)
-  const bufferBytes = new Uint8Array(buffer);
-  const hashTimerDigest = sha256(bufferBytes);
-  const hashTimerDigestHex = Array.from(hashTimerDigest).map(b => b.toString(16).padStart(2, '0')).join('');
-  
-  return {
-    version: 'v1',
-    time: {
-      t_ns: timestamp_ns.toString(),
-      precision_ns: 100,
-      drift_ns: drift_ns.toString()
-    },
-    position: {
-      round: round.toString(),
-      seq: sequence,
-      kind
-    },
-    node_id: nodeIdHex,
-    payload_digest: finalPayloadDigest,
-    hash_timer_digest: hashTimerDigestHex
-  };
-};
+const ITEMS_PER_PAGE = 20
 
-// Mock SHA-256 function (in real implementation, use crypto.subtle.digest)
-const sha256 = (_data: Uint8Array): Uint8Array => {
-  // This is a mock implementation - in production, use proper SHA-256
-  const hash = new Uint8Array(32);
-  for (let i = 0; i < 32; i++) {
-    hash[i] = Math.floor(Math.random() * 256);
-  }
-  return hash;
-};
+const formatAmount = (value: number) => new Intl.NumberFormat(undefined, {
+  minimumFractionDigits: 0,
+  maximumFractionDigits: 6,
+}).format(value)
+
+const formatTimestamp = (value: number) => {
+  if (!value) return '—'
+  const millis = Math.floor(value / 1_000)
+  return new Date(millis).toLocaleString()
+}
+
+const shortValue = (value: string) => {
+  if (!value) return '—'
+  return value.length <= 16 ? value : `${value.slice(0, 10)}…${value.slice(-6)}`
+}
 
 export default function TransactionsPage() {
-  const navigate = useNavigate()
   const [transactions, setTransactions] = useState<Transaction[]>([])
-  const [isLoading, setIsLoading] = useState(true)
   const [selectedTx, setSelectedTx] = useState<Transaction | null>(null)
   const [searchTerm, setSearchTerm] = useState('')
-  const [filterType, setFilterType] = useState<string>('all')
+  const [filterType, setFilterType] = useState<'all' | 'send' | 'receive' | 'self' | 'other'>('all')
   const [currentPage, setCurrentPage] = useState(1)
-  const [itemsPerPage] = useState(20)
+  const [isLoading, setIsLoading] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const [lastAddress, setLastAddress] = useState<string | null>(null)
+  const [searchParams, setSearchParams] = useSearchParams()
+  const initialAddress = searchParams.get('address')
 
-  // Helper function to create canonical IPPAN transactions
-  const createTransaction = (blockId: string, txIndex: number, timestamp: number, nodeId: string, round: number, sequence: number): Transaction => {
-    const txHash = Array.from({length: 64}, () => Math.floor(Math.random() * 16).toString(16)).join('');
-    const from = Array.from({length: 64}, () => Math.floor(Math.random() * 16).toString(16)).join('');
-    const to = Array.from({length: 64}, () => Math.floor(Math.random() * 16).toString(16)).join('');
-    const amount = (Math.floor(Math.random() * 1000000) + 1000).toString();
-    const fee = Math.floor(Math.random() * 1000) + 100;
-    const nonce = Math.floor(Math.random() * 10000) + 1;
-    const signature = Array.from({length: 128}, () => Math.floor(Math.random() * 16).toString(16)).join('');
-    
-    // Randomly assign confidentiality level (70% public, 20% private, 10% confidential)
-    const confidentialityRand = Math.random();
-    const confidentiality: 'public' | 'private' | 'confidential' = 
-      confidentialityRand < 0.7 ? 'public' : 
-      confidentialityRand < 0.9 ? 'private' : 'confidential';
-    
-    // Generate block parents for context
-    const blockParents = [
-      Array.from({length: 64}, () => Math.floor(Math.random() * 16).toString(16)).join(''),
-      Array.from({length: 64}, () => Math.floor(Math.random() * 16).toString(16)).join('')
-    ];
-    const blockParentRounds = [(round - 1).toString(), (round - 2).toString()];
-    
-    const hashtimer = createHashTimer(timestamp, nodeId, round, sequence, 'Tx');
-    
-    // Generate appropriate memo based on confidentiality
-    let memo = '';
-    if (confidentiality === 'public') {
-      memo = `Transaction ${txIndex} in block ${blockId}`;
-    } else if (confidentiality === 'private') {
-      memo = '[Private Transaction]';
-    } else {
-      memo = '[Confidential Transaction]';
+  const fetchTransactions = async (addressInput: string) => {
+    const address = addressInput.trim()
+    if (!address) {
+      setError('Enter an IPPAN address to lookup transactions.')
+      return
     }
-    
-    return {
-      tx_hash: txHash,
-      from,
-      to,
-      amount,
-      fee,
-      nonce,
-      memo,
-      signature,
-      hashtimer,
-      block_id: blockId,
-      block_parents: blockParents,
-      block_parent_rounds: blockParentRounds,
-      confidentiality
-    };
-  };
 
-  // Mock data for demonstration
+    setIsLoading(true)
+    setError(null)
+    setSelectedTx(null)
+    setTransactions([])
+
+    try {
+      const response = await getWalletTransactions(address)
+      const parsed: Transaction[] = (response || []).map((tx: any) => ({
+        id: tx.id ?? tx.tx_hash ?? '',
+        from: tx.from ?? '',
+        to: tx.to ?? '',
+        amount: typeof tx.amount === 'string' ? Number(tx.amount) : tx.amount ?? 0,
+        nonce: tx.nonce ?? 0,
+        timestamp: typeof tx.timestamp === 'number'
+          ? tx.timestamp
+          : Number(tx.timestamp?.us ?? tx.timestamp?.[0] ?? 0),
+        direction: (tx.direction ?? 'other') as Transaction['direction'],
+        hashtimer: tx.hashtimer ?? '',
+      }))
+
+      setTransactions(parsed)
+      setCurrentPage(1)
+      setLastAddress(address)
+
+      if (parsed.length === 0) {
+        setError('No transactions found for this address yet.')
+      }
+    } catch (err: any) {
+      console.error('Failed to fetch transactions', err)
+      setError(err?.message || 'Unable to fetch transactions. Ensure the node RPC service is running.')
+    } finally {
+      setIsLoading(false)
+    }
+  }
+
+  const handleSearch = () => {
+    fetchTransactions(searchTerm)
+    if (searchTerm.trim()) {
+      setSearchParams({ address: searchTerm.trim() })
+    }
+  }
+
   useEffect(() => {
-    const now = Date.now();
-    const mockTransactions: Transaction[] = [];
-    
-    // Generate transactions across multiple blocks and rounds
-    for (let blockIndex = 0; blockIndex < 5; blockIndex++) {
-      const blockId = `block-${1234560 + blockIndex}`;
-      const blockTimestamp = now - (blockIndex * 10000);
-      const round = 8784975000 + blockIndex;
-      const nodeId = `validator-${(blockIndex % 3) + 1}`;
-      
-      // Generate 3-8 transactions per block
-      const txCount = Math.floor(Math.random() * 6) + 3;
-      for (let txIndex = 0; txIndex < txCount; txIndex++) {
-        const txTimestamp = blockTimestamp + (txIndex * 1000);
-        const transaction = createTransaction(blockId, txIndex, txTimestamp, nodeId, round, txIndex + 1);
-        mockTransactions.push(transaction);
-      }
+    if (initialAddress) {
+      setSearchTerm(initialAddress)
+      fetchTransactions(initialAddress)
     }
-    
-    // Sort transactions by HashTimer (canonical ordering)
-    mockTransactions.sort((a, b) => {
-      const aTime = BigInt(a.hashtimer.time.t_ns);
-      const bTime = BigInt(b.hashtimer.time.t_ns);
-      if (aTime !== bTime) return aTime < bTime ? -1 : 1;
-      
-      const aRound = BigInt(a.hashtimer.position.round);
-      const bRound = BigInt(b.hashtimer.position.round);
-      if (aRound !== bRound) return aRound < bRound ? -1 : 1;
-      
-      if (a.hashtimer.position.seq !== b.hashtimer.position.seq) {
-        return a.hashtimer.position.seq - b.hashtimer.position.seq;
-      }
-      
-      if (a.hashtimer.node_id !== b.hashtimer.node_id) {
-        return a.hashtimer.node_id.localeCompare(b.hashtimer.node_id);
-      }
-      
-      return a.hashtimer.payload_digest.localeCompare(b.hashtimer.payload_digest);
-    });
-
-    setTransactions(mockTransactions)
-    setIsLoading(false)
+  // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [])
 
-  // Filter transactions based on search and type
-  const filteredTransactions = transactions.filter(tx => {
-    const matchesSearch = 
-      tx.tx_hash.toLowerCase().includes(searchTerm.toLowerCase()) ||
-      tx.from.toLowerCase().includes(searchTerm.toLowerCase()) ||
-      tx.to.toLowerCase().includes(searchTerm.toLowerCase()) ||
-      tx.amount.toLowerCase().includes(searchTerm.toLowerCase()) ||
-      tx.block_id?.toLowerCase().includes(searchTerm.toLowerCase()) ||
-      tx.hashtimer.position.round.includes(searchTerm)
-    
-    // For now, we'll use a simple type filter based on amount or memo
-    const matchesType = filterType === 'all' || 
-      (filterType === 'transfer' && parseInt(tx.amount) > 0) ||
-      (filterType === 'stake' && tx.memo?.includes('stake')) ||
-      (filterType === 'contract' && tx.memo?.includes('contract')) ||
-      (filterType === 'ai_job' && tx.memo?.includes('AI'))
-    
-    return matchesSearch && matchesType
-  })
+  const filteredTransactions = useMemo(() => {
+    return transactions.filter((tx) => {
+      if (filterType === 'all') return true
+      return tx.direction === filterType
+    })
+  }, [transactions, filterType])
 
-  // Pagination
-  const totalPages = Math.ceil(filteredTransactions.length / itemsPerPage)
-  const startIndex = (currentPage - 1) * itemsPerPage
-  const paginatedTransactions = filteredTransactions.slice(startIndex, startIndex + itemsPerPage)
+  const totalPages = Math.max(1, Math.ceil(filteredTransactions.length / ITEMS_PER_PAGE))
+  const pageStart = (currentPage - 1) * ITEMS_PER_PAGE
+  const paginatedTransactions = filteredTransactions.slice(pageStart, pageStart + ITEMS_PER_PAGE)
 
-  const getStatusColor = (tx: Transaction) => {
-    // Determine status based on HashTimer and block info
-    const now = BigInt(Date.now() * 1_000_000); // Convert to nanoseconds
-    const txTime = BigInt(tx.hashtimer.time.t_ns);
-    const timeDiff = Number(now - txTime);
-    
-    if (timeDiff < 30_000_000_000) { // Less than 30 seconds
-      return 'warning'; // pending
-    } else if (tx.block_id) {
-      return 'success'; // confirmed
-    } else {
-      return 'error'; // failed
-    }
+  const directionLabel: Record<Transaction['direction'], string> = {
+    send: 'Sent',
+    receive: 'Received',
+    self: 'Self Transfer',
+    other: 'Other',
   }
 
-  const getTypeColor = (tx: Transaction) => {
-    if (parseInt(tx.amount) === 0) return 'purple'; // contract
-    if (tx.memo?.includes('stake')) return 'green'; // stake
-    if (tx.memo?.includes('AI')) return 'pink'; // ai_job
-    return 'blue'; // transfer
-  }
-
-  const getTransactionType = (tx: Transaction) => {
-    if (parseInt(tx.amount) === 0) return 'contract';
-    if (tx.memo?.includes('stake')) return 'stake';
-    if (tx.memo?.includes('AI')) return 'ai_job';
-    return 'transfer';
-  }
-
-  const getConfidentialityColor = (confidentiality?: string) => {
-    switch (confidentiality) {
-      case 'public': return 'default';
-      case 'private': return 'warning';
-      case 'confidential': return 'error';
-      default: return 'default';
-    }
-  }
-
-  const getConfidentialityIcon = (confidentiality?: string) => {
-    switch (confidentiality) {
-      case 'public': return '🌐';
-      case 'private': return '🔒';
-      case 'confidential': return '🛡️';
-      default: return '🌐';
-    }
-  }
-
-  const handleViewBlock = () => {
-    if (selectedTx?.block_id) {
-      // Navigate to Live Blocks page with block ID as a query parameter
-      navigate(`/explorer/live-blocks?block=${selectedTx.block_id}`)
-    }
-  }
-
-  if (isLoading) {
-    return (
-      <div className="flex justify-center items-center h-64">
-        <LoadingSpinner />
-      </div>
-    )
+  const directionVariant: Record<Transaction['direction'], 'success' | 'warning' | 'default'> = {
+    send: 'warning',
+    receive: 'success',
+    self: 'default',
+    other: 'default',
   }
 
   return (
     <div className="space-y-6">
-      <div className="flex justify-between items-center">
-        <h1 className="text-2xl font-bold text-gray-900">Transactions</h1>
-        <Badge variant="success">Live Network</Badge>
+      <div className="flex flex-col md:flex-row md:items-center md:justify-between gap-3">
+        <div>
+          <h1 className="text-2xl font-bold text-gray-900">Transactions</h1>
+          <p className="text-sm text-gray-600">
+            Look up confirmed transactions directly from the node RPC interface.
+          </p>
+        </div>
+        <Badge variant="success">Live RPC</Badge>
       </div>
 
-      {/* Search and Filters */}
-      <Card title="Search & Filters">
+      <Card title="Lookup Transactions by Address">
         <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
-          <Field label="Search Transactions">
+          <Field label="IPPAN Address">
             <Input
-              placeholder="Search by hash, address, or amount..."
+              placeholder="i0000…"
               value={searchTerm}
-              onChange={(e) => setSearchTerm(e.target.value)}
+              onChange={(event) => setSearchTerm(event.target.value)}
+              onKeyDown={(event) => {
+                if (event.key === 'Enter') {
+                  event.preventDefault()
+                  handleSearch()
+                }
+              }}
             />
           </Field>
-          <Field label="Transaction Type">
+
+          <Field label="Direction Filter">
             <select
               value={filterType}
-              onChange={(e) => setFilterType(e.target.value)}
+              onChange={(event) => {
+                setFilterType(event.target.value as typeof filterType)
+                setCurrentPage(1)
+              }}
               className="w-full p-2 border border-gray-300 rounded-md"
             >
-              <option value="all">All Types</option>
-              <option value="transfer">Transfer</option>
-              <option value="stake">Stake</option>
-              <option value="unstake">Unstake</option>
-              <option value="contract">Smart Contract</option>
-              <option value="ai_job">AI Job</option>
+              <option value="all">All directions</option>
+              <option value="receive">Inbound</option>
+              <option value="send">Outbound</option>
+              <option value="self">Self</option>
+              <option value="other">Other</option>
             </select>
           </Field>
+
           <div className="flex items-end">
-            <Button className="w-full">Search</Button>
+            <Button className="w-full" onClick={handleSearch} disabled={isLoading}>
+              {isLoading ? 'Loading…' : 'Fetch Transactions'}
+            </Button>
           </div>
         </div>
+
+        <p className="text-xs text-gray-500 mt-3">
+          The RPC server returns transactions for the provided address directly from storage.
+          Results are limited to the records currently retained by the node.
+        </p>
+
+        {error && (
+          <div className="mt-3 text-sm text-red-600 bg-red-50 border border-red-200 rounded-md p-3">
+            {error}
+          </div>
+        )}
       </Card>
 
-      <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
-        {/* Transaction List */}
-        <div className="lg:col-span-2">
-          <Card title={`Transactions (${filteredTransactions.length})`}>
-            <div className="space-y-3">
-              {paginatedTransactions.map((tx) => (
-                <div
-                  key={tx.tx_hash}
-                  className={`p-4 border rounded-lg cursor-pointer transition-all hover:shadow-md ${
-                    selectedTx?.tx_hash === tx.tx_hash ? 'border-blue-500 bg-blue-50' : 'border-gray-200'
-                  }`}
-                  onClick={() => setSelectedTx(tx)}
-                >
-                  <div className="flex justify-between items-start">
-                    <div className="flex-1">
-                      <div className="flex items-center space-x-2 mb-2">
-                        <Badge variant={getTypeColor(tx) as any}>
-                          {getTransactionType(tx).replace('_', ' ').toUpperCase()}
-                        </Badge>
-                        <Badge variant={getStatusColor(tx) as any}>
-                          {getStatusColor(tx) === 'warning' ? 'pending' : 
-                           getStatusColor(tx) === 'success' ? 'confirmed' : 'failed'}
-                        </Badge>
-                        <Badge variant={getConfidentialityColor(tx.confidentiality) as any}>
-                          {getConfidentialityIcon(tx.confidentiality)} {tx.confidentiality?.toUpperCase() || 'PUBLIC'}
-                        </Badge>
-                        <span className="text-sm text-gray-600">Block {tx.block_id}</span>
-                        <span className="text-sm text-gray-600">Round {tx.hashtimer.position.round}</span>
-                      </div>
-                      <div className="text-sm text-gray-600 space-y-1">
-                        <div>Hash: {tx.tx_hash.substring(0, 16)}...</div>
-                        <div>From: {tx.confidentiality === 'public' ? `${tx.from.substring(0, 16)}...` : 
-                                   tx.confidentiality === 'private' ? '[Encrypted]' : '[Confidential]'}</div>
-                        <div>To: {tx.confidentiality === 'public' ? `${tx.to.substring(0, 16)}...` : 
-                                 tx.confidentiality === 'private' ? '[Encrypted]' : '[Confidential]'}</div>
-                        <div>Amount: {tx.confidentiality === 'public' ? `${tx.amount} IPPAN` : 
-                                     tx.confidentiality === 'private' ? '[Encrypted]' : '[Confidential]'}</div>
-                        <div>HashTimer: {tx.hashtimer.time.t_ns}ns</div>
-                      </div>
-                    </div>
-                    <div className="text-right text-sm text-gray-600">
-                      <div>{tx.confidentiality === 'public' ? `${tx.amount} IPPAN` : 
-                             tx.confidentiality === 'private' ? '[Encrypted]' : '[Confidential]'}</div>
-                      <div>Fee: {tx.fee}</div>
-                      <div>{new Date(parseInt(tx.hashtimer.time.t_ns) / 1_000_000).toLocaleTimeString()}</div>
-                    </div>
-                  </div>
-                </div>
-              ))}
-            </div>
-
-            {/* Pagination */}
-            {totalPages > 1 && (
-              <div className="flex justify-center items-center space-x-2 mt-6">
-                <Button
-                  onClick={() => setCurrentPage(Math.max(1, currentPage - 1))}
-                  disabled={currentPage === 1}
-                  className="px-3 py-1"
-                >
-                  Previous
-                </Button>
-                <span className="text-sm text-gray-600">
-                  Page {currentPage} of {totalPages}
-                </span>
-                <Button
-                  onClick={() => setCurrentPage(Math.min(totalPages, currentPage + 1))}
-                  disabled={currentPage === totalPages}
-                  className="px-3 py-1"
-                >
-                  Next
-                </Button>
-              </div>
-            )}
-          </Card>
-        </div>
-
-        {/* Transaction Details */}
-        <div className="lg:col-span-1">
-          <Card title="Transaction Details">
-            {selectedTx ? (
-              <div className="space-y-4">
-                <div>
-                  <label className="block text-sm font-medium text-gray-700">Transaction Hash</label>
-                  <div className="font-mono text-xs break-all">{selectedTx.tx_hash}</div>
-                </div>
-                <div>
-                  <label className="block text-sm font-medium text-gray-700">Block ID</label>
-                  <div className="font-mono text-lg">{selectedTx.block_id}</div>
-                </div>
-                <div>
-                  <label className="block text-sm font-medium text-gray-700">From Address</label>
-                  <div className="font-mono text-xs break-all">
-                    {selectedTx.confidentiality === 'public' ? selectedTx.from : 
-                     selectedTx.confidentiality === 'private' ? '[Encrypted Address]' : 
-                     '[Confidential Address]'}
-                  </div>
-                </div>
-                <div>
-                  <label className="block text-sm font-medium text-gray-700">To Address</label>
-                  <div className="font-mono text-xs break-all">
-                    {selectedTx.confidentiality === 'public' ? selectedTx.to : 
-                     selectedTx.confidentiality === 'private' ? '[Encrypted Address]' : 
-                     '[Confidential Address]'}
-                  </div>
-                </div>
-                <div>
-                  <label className="block text-sm font-medium text-gray-700">Amount</label>
-                  <div className="text-lg font-bold">
-                    {selectedTx.confidentiality === 'public' ? `${selectedTx.amount} IPPAN` : 
-                     selectedTx.confidentiality === 'private' ? '[Encrypted Amount]' : 
-                     '[Confidential Amount]'}
-                  </div>
-                </div>
-                <div>
-                  <label className="block text-sm font-medium text-gray-700">Fee</label>
-                  <div className="text-sm">{selectedTx.fee}</div>
-                </div>
-                <div>
-                  <label className="block text-sm font-medium text-gray-700">Nonce</label>
-                  <div className="text-sm">{selectedTx.nonce}</div>
-                </div>
-                <div>
-                  <label className="block text-sm font-medium text-gray-700">Memo</label>
-                  <div className="text-sm">{selectedTx.memo || 'None'}</div>
-                </div>
-                <div>
-                  <label className="block text-sm font-medium text-gray-700">Type</label>
-                  <Badge variant={getTypeColor(selectedTx) as any}>
-                    {getTransactionType(selectedTx).replace('_', ' ').toUpperCase()}
-                  </Badge>
-                </div>
-                <div>
-                  <label className="block text-sm font-medium text-gray-700">Status</label>
-                  <Badge variant={getStatusColor(selectedTx) as any}>
-                    {getStatusColor(selectedTx) === 'warning' ? 'pending' : 
-                     getStatusColor(selectedTx) === 'success' ? 'confirmed' : 'failed'}
-                  </Badge>
-                </div>
-                <div>
-                  <label className="block text-sm font-medium text-gray-700">Confidentiality</label>
-                  <Badge variant={getConfidentialityColor(selectedTx.confidentiality) as any}>
-                    {getConfidentialityIcon(selectedTx.confidentiality)} {selectedTx.confidentiality?.toUpperCase() || 'PUBLIC'}
-                  </Badge>
-                  <div className="text-xs text-gray-500 mt-1">
-                    {selectedTx.confidentiality === 'public' && 'Transaction details are publicly visible'}
-                    {selectedTx.confidentiality === 'private' && 'Transaction details are encrypted and private'}
-                    {selectedTx.confidentiality === 'confidential' && 'Transaction uses advanced confidentiality protocols'}
-                  </div>
-                </div>
-                
-                {/* HashTimer Details */}
-                <div className="border-t pt-4">
-                  <h4 className="font-medium text-gray-700 mb-2">HashTimer Details (v1)</h4>
-                  <div className="space-y-2 text-sm">
-                    <div>
-                      <span className="font-medium">Time (ns):</span> {selectedTx.hashtimer.time.t_ns}
-                    </div>
-                    <div>
-                      <span className="font-medium">Precision:</span> {selectedTx.hashtimer.time.precision_ns}ns
-                    </div>
-                    <div>
-                      <span className="font-medium">Drift:</span> {selectedTx.hashtimer.time.drift_ns}ns
-                    </div>
-                    <div>
-                      <span className="font-medium">Round:</span> {selectedTx.hashtimer.position.round}
-                    </div>
-                    <div>
-                      <span className="font-medium">Sequence:</span> {selectedTx.hashtimer.position.seq}
-                    </div>
-                    <div>
-                      <span className="font-medium">Kind:</span> {selectedTx.hashtimer.position.kind}
-                    </div>
-                    <div>
-                      <span className="font-medium">Node ID:</span> {selectedTx.hashtimer.node_id.substring(0, 16)}...
-                    </div>
-                    <div>
-                      <span className="font-medium">Payload Digest:</span> {selectedTx.hashtimer.payload_digest.substring(0, 16)}...
-                    </div>
-                    <div>
-                      <span className="font-medium">HashTimer Digest:</span> {selectedTx.hashtimer.hash_timer_digest.substring(0, 16)}...
-                    </div>
-                  </div>
-                </div>
-
-                {/* Block Parents */}
-                {selectedTx.block_parents && selectedTx.block_parents.length > 0 && (
-                  <div className="border-t pt-4">
-                    <h4 className="font-medium text-gray-700 mb-2">Block Parents ({selectedTx.block_parents.length})</h4>
-                    <div className="space-y-2">
-                      {selectedTx.block_parents.map((parent, index) => (
-                        <div key={index} className="flex items-center space-x-2">
-                          <span className="text-xs text-gray-500">Round {selectedTx.block_parent_rounds?.[index]}:</span>
-                          <span className="text-xs font-mono bg-gray-100 px-2 py-1 rounded">
-                            {parent.substring(0, 8)}...{parent.substring(56)}
-                          </span>
-                        </div>
-                      ))}
-                    </div>
-                  </div>
-                )}
-
-                <div>
-                  <label className="block text-sm font-medium text-gray-700">Timestamp</label>
-                  <div className="text-sm">{new Date(parseInt(selectedTx.hashtimer.time.t_ns) / 1_000_000).toLocaleString()}</div>
-                </div>
-                <Button 
-                  className="w-full" 
-                  onClick={handleViewBlock}
-                  disabled={!selectedTx?.block_id}
-                >
-                  View Block
-                </Button>
-              </div>
-            ) : (
-              <div className="text-center text-gray-500 py-8">
-                Select a transaction to view details
-              </div>
-            )}
-          </Card>
-        </div>
-      </div>
-
-      {/* Statistics */}
-      <Card title="Transaction Statistics">
-        <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
-          <div className="text-center">
-            <div className="text-2xl font-bold text-blue-600">{transactions.length}</div>
-            <div className="text-sm text-gray-600">Total Transactions</div>
+      <Card title={`Transactions ${lastAddress ? `for ${shortValue(lastAddress)}` : ''}`}>
+        {isLoading ? (
+          <div className="flex justify-center items-center h-48">
+            <LoadingSpinner />
           </div>
-          <div className="text-center">
-            <div className="text-2xl font-bold text-green-600">
-              {transactions.filter(tx => getStatusColor(tx) === 'success').length}
-            </div>
-            <div className="text-sm text-gray-600">Confirmed</div>
+        ) : paginatedTransactions.length === 0 ? (
+          <div className="text-center text-gray-500 py-12">
+            {lastAddress
+              ? 'No transactions available for this address yet.'
+              : 'Enter an address above to load transactions.'}
           </div>
-          <div className="text-center">
-            <div className="text-2xl font-bold text-yellow-600">
-              {transactions.filter(tx => getStatusColor(tx) === 'warning').length}
-            </div>
-            <div className="text-sm text-gray-600">Pending</div>
+        ) : (
+          <div className="space-y-3">
+            {paginatedTransactions.map((tx) => (
+              <button
+                key={tx.id}
+                type="button"
+                onClick={() => setSelectedTx(tx)}
+                className={`w-full text-left border rounded-lg p-4 transition-all ${
+                  selectedTx?.id === tx.id ? 'border-blue-500 bg-blue-50' : 'border-gray-200 hover:border-blue-400'
+                }`}
+              >
+                <div className="flex flex-wrap items-center gap-2 mb-2">
+                  <Badge variant={directionVariant[tx.direction]}>{directionLabel[tx.direction]}</Badge>
+                  <span className="text-sm text-gray-600">Nonce {tx.nonce}</span>
+                  <span className="text-sm text-gray-600">{formatTimestamp(tx.timestamp)}</span>
+                </div>
+                <div className="text-sm text-gray-700 space-y-1">
+                  <div><strong>Hash:</strong> {shortValue(tx.id)}</div>
+                  <div><strong>From:</strong> {shortValue(tx.from)}</div>
+                  <div><strong>To:</strong> {shortValue(tx.to)}</div>
+                  <div><strong>Amount:</strong> {formatAmount(tx.amount)} IPN</div>
+                </div>
+              </button>
+            ))}
           </div>
-          <div className="text-center">
-            <div className="text-2xl font-bold text-red-600">
-              {transactions.filter(tx => getStatusColor(tx) === 'error').length}
+        )}
+
+        {paginatedTransactions.length > 0 && (
+          <div className="flex justify-between items-center mt-4 text-sm text-gray-600">
+            <span>
+              Showing {pageStart + 1}–{Math.min(pageStart + ITEMS_PER_PAGE, filteredTransactions.length)} of
+              {' '}
+              {filteredTransactions.length}
+            </span>
+            <div className="flex items-center gap-2">
+              <Button
+                variant="ghost"
+                disabled={currentPage === 1}
+                onClick={() => setCurrentPage((page) => Math.max(1, page - 1))}
+              >
+                Previous
+              </Button>
+              <span>Page {currentPage} of {totalPages}</span>
+              <Button
+                variant="ghost"
+                disabled={currentPage === totalPages}
+                onClick={() => setCurrentPage((page) => Math.min(totalPages, page + 1))}
+              >
+                Next
+              </Button>
             </div>
-            <div className="text-sm text-gray-600">Failed</div>
           </div>
-        </div>
+        )}
       </Card>
+
+      {selectedTx && (
+        <Card title="Transaction Details">
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-4 text-sm text-gray-700">
+            <div>
+              <h3 className="font-semibold text-gray-900 mb-2">Identifiers</h3>
+              <p><strong>Transaction Hash:</strong> {selectedTx.id}</p>
+              <p><strong>HashTimer:</strong> {selectedTx.hashtimer || '—'}</p>
+              <p><strong>Timestamp:</strong> {formatTimestamp(selectedTx.timestamp)}</p>
+            </div>
+            <div>
+              <h3 className="font-semibold text-gray-900 mb-2">Participants</h3>
+              <p><strong>From:</strong> {selectedTx.from}</p>
+              <p><strong>To:</strong> {selectedTx.to}</p>
+              <p><strong>Direction:</strong> {directionLabel[selectedTx.direction]}</p>
+              <p><strong>Amount:</strong> {formatAmount(selectedTx.amount)} IPN</p>
+            </div>
+          </div>
+        </Card>
+      )}
     </div>
   )
 }


### PR DESCRIPTION
## Summary
- replace the explorer transactions page mock data with live RPC lookups driven by the wallet transaction API
- rebuild the accounts explorer page to list real node accounts with search, sorting, and quick actions
- add an API helper for fetching accounts from the RPC layer

## Testing
- npm run lint *(fails: ESLint configuration missing in repository)*

------
https://chatgpt.com/codex/tasks/task_e_68d4e671f14c832ba10266fe42c96cf5