### PR TITLE
Fix transaction hash recomputation

### DIFF
--- a/crates/types/src/transaction.rs
+++ b/crates/types/src/transaction.rs
@@ -56,6 +56,14 @@ impl Transaction {
         self.id = self.compute_hash();
     }
 
+    /// Compute the canonical transaction hash using BLAKE3.
+    fn compute_hash(&self) -> [u8; 32] {
+        let hash = blake3::hash(&self.canonical_bytes());
+        let mut result = [0u8; 32];
+        result.copy_from_slice(hash.as_bytes());
+        result
+    }
+
     /// Create payload for HashTimer computation
     fn create_payload(from: &[u8; 32], to: &[u8; 32], amount: u64, nonce: u64) -> Vec<u8> {
         let mut payload = Vec::new();
@@ -121,10 +129,7 @@ impl Transaction {
 
     /// Get transaction hash
     pub fn hash(&self) -> [u8; 32] {
-        let hash = blake3::hash(&self.canonical_bytes());
-        let mut result = [0u8; 32];
-        result.copy_from_slice(hash.as_bytes());
-        result
+        self.compute_hash()
     }
 
     /// Check if transaction is valid


### PR DESCRIPTION
## Summary
- add a dedicated `compute_hash` helper for transactions so their IDs can be refreshed correctly
- reuse the helper from the `hash` accessor to guarantee consistent BLAKE3 hashing

## Testing
- cargo test -p ippan-types

------
https://chatgpt.com/codex/tasks/task_e_68d4edccbb34832b8271e94b18a1ed0e