### PR TITLE
Improve NAT-aware peer discovery

### DIFF
--- a/crates/p2p/src/lib.rs
+++ b/crates/p2p/src/lib.rs
@@ -1,4 +1,4 @@
-use anyhow::{anyhow, Context, Result};
+use anyhow::{anyhow, Result};
 use ippan_types::{Block, Transaction};
 use reqwest::Client;
 use serde::{Deserialize, Serialize};
@@ -103,6 +103,9 @@ pub struct HttpP2PNetwork {
     is_running: Arc<parking_lot::RwLock<bool>>,
     local_peer_id: String,
     listen_address: String,
+    listen_host: String,
+    listen_port: u16,
+    listen_scheme: String,
     announce_address: Arc<parking_lot::RwLock<String>>,
     upnp_mapping_active: Arc<parking_lot::RwLock<bool>>,
 }
@@ -111,6 +114,17 @@ impl HttpP2PNetwork {
     /// Create a new HTTP P2P network
     pub fn new(config: P2PConfig, local_address: String) -> Result<Self> {
         let client = Client::builder().timeout(config.message_timeout).build()?;
+
+        let canonical_listen = Self::canonicalize_address(&local_address)?;
+        let listen_url: Url = canonical_listen.parse()?;
+        let listen_host = listen_url
+            .host_str()
+            .ok_or_else(|| anyhow!("listen address must include a host"))?
+            .to_string();
+        let listen_port = listen_url
+            .port_or_known_default()
+            .ok_or_else(|| anyhow!("listen address must include a port"))?;
+        let listen_scheme = listen_url.scheme().to_string();
 
         // Generate a simple peer ID
         let local_peer_id = format!(
@@ -133,8 +147,11 @@ impl HttpP2PNetwork {
             peer_count: Arc::new(parking_lot::RwLock::new(0)),
             is_running: Arc::new(parking_lot::RwLock::new(false)),
             local_peer_id,
-            listen_address: listen_address.clone(),
-            announce_address: Arc::new(parking_lot::RwLock::new(listen_address)),
+            listen_address: canonical_listen.clone(),
+            listen_host,
+            listen_port,
+            listen_scheme,
+            announce_address: Arc::new(parking_lot::RwLock::new(canonical_listen)),
             upnp_mapping_active: Arc::new(parking_lot::RwLock::new(false)),
         })
     }
@@ -142,7 +159,7 @@ impl HttpP2PNetwork {
     /// Start the P2P network
     pub async fn start(&mut self) -> Result<()> {
         *self.is_running.write() = true;
-        info!("Starting HTTP P2P network on {}", self.local_address);
+        info!("Starting HTTP P2P network on {}", self.listen_address);
 
         // Add bootstrap peers
         for peer in &self.config.bootstrap_peers {
@@ -188,7 +205,8 @@ impl HttpP2PNetwork {
             let peers = self.peers.clone();
             let client = self.client.clone();
             let config = self.config.clone();
-            let local_address = self.local_address.clone();
+            let announce_address = self.announce_address.clone();
+            let peer_count = self.peer_count.clone();
 
             tokio::spawn(async move {
                 let mut interval = interval(config.peer_discovery_interval);
@@ -199,7 +217,79 @@ impl HttpP2PNetwork {
                     }
 
                     interval.tick().await;
-                    Self::discover_peers(&client, &peers, &local_address).await;
+                    let local_address = announce_address.read().clone();
+                    if let Err(e) =
+                        Self::discover_peers(&client, &peers, &local_address, &peer_count).await
+                    {
+                        debug!("Peer discovery attempt failed: {}", e);
+                    }
+                }
+            })
+        };
+
+        if let Err(e) = Self::refresh_announce_address_inner(
+            &self.client,
+            &self.config,
+            &self.listen_host,
+            &self.listen_scheme,
+            self.listen_port,
+            &self.announce_address,
+            &self.upnp_mapping_active,
+        )
+        .await
+        {
+            warn!("Failed to determine announce address: {}", e);
+        }
+
+        if let Err(e) = self.announce_self() {
+            warn!("Failed to queue initial peer announcement: {}", e);
+        }
+
+        let _announce_handle = {
+            let is_running = self.is_running.clone();
+            let client = self.client.clone();
+            let config = self.config.clone();
+            let listen_host = self.listen_host.clone();
+            let listen_scheme = self.listen_scheme.clone();
+            let listen_port = self.listen_port;
+            let announce_address = self.announce_address.clone();
+            let upnp_mapping_active = self.upnp_mapping_active.clone();
+            let message_sender = self.message_sender.clone();
+            let local_peer_id = self.local_peer_id.clone();
+
+            tokio::spawn(async move {
+                let mut interval = interval(config.peer_announce_interval);
+
+                loop {
+                    if !*is_running.read() {
+                        break;
+                    }
+
+                    interval.tick().await;
+
+                    if let Err(e) = HttpP2PNetwork::refresh_announce_address_inner(
+                        &client,
+                        &config,
+                        &listen_host,
+                        &listen_scheme,
+                        listen_port,
+                        &announce_address,
+                        &upnp_mapping_active,
+                    )
+                    .await
+                    {
+                        warn!("Failed to refresh announce address: {}", e);
+                    }
+
+                    let address = announce_address.read().clone();
+                    let message = NetworkMessage::PeerInfo {
+                        peer_id: local_peer_id.clone(),
+                        addresses: vec![address],
+                    };
+
+                    if let Err(e) = message_sender.send(message) {
+                        warn!("Failed to queue peer announcement: {}", e);
+                    }
                 }
             })
         };
@@ -213,6 +303,12 @@ impl HttpP2PNetwork {
         *self.is_running.write() = false;
         info!("Stopping HTTP P2P network");
 
+        if let Err(e) =
+            Self::teardown_upnp_mapping(self.listen_port, &self.upnp_mapping_active).await
+        {
+            warn!("Failed to remove UPnP port mapping: {}", e);
+        }
+
         // Wait a bit for the network loops to finish
         sleep(Duration::from_millis(100)).await;
 
@@ -223,38 +319,43 @@ impl HttpP2PNetwork {
     /// Add a peer to the network
     pub async fn add_peer(&self, peer_address: String) -> Result<()> {
         // Validate URL
-        let _url: Url = peer_address.parse()?;
+        let canonical = Self::canonicalize_address(&peer_address)?;
 
-        // Add to peers set
-        {
+        if canonical == self.listen_address || canonical == self.get_announce_address() {
+            return Ok(());
+        }
+
+        let inserted = {
             let mut peers = self.peers.write();
 
             if peers.contains(&canonical) {
-                return Ok(());
+                false
+            } else {
+                if peers.len() >= self.config.max_peers {
+                    warn!(
+                        "Peer limit reached ({}). Skipping peer {}",
+                        self.config.max_peers, canonical
+                    );
+                    false
+                } else {
+                    peers.insert(canonical.clone());
+                    true
+                }
             }
-
-            if peers.len() >= self.config.max_peers {
-                warn!(
-                    "Peer limit reached ({}). Skipping peer {}",
-                    self.config.max_peers, canonical
-                );
-                return Ok(());
-            }
-
-            peers.insert(canonical.clone())
         };
 
         if !inserted {
             return Ok(());
         }
 
-        // Update peer count
-        {
-            let mut count = self.peer_count.write();
-            *count = self.peers.read().len();
+        self.update_peer_count();
+
+        info!("Added peer: {}", canonical);
+
+        if let Err(e) = self.announce_self() {
+            debug!("Failed to announce self after adding peer: {}", e);
         }
 
-        info!("Added peer: {}", peer_address);
         Ok(())
     }
 
@@ -262,15 +363,15 @@ impl HttpP2PNetwork {
     pub fn remove_peer(&self, peer_address: &str) {
         match Self::canonicalize_address(peer_address) {
             Ok(canonical) => {
-                {
+                let removed = {
                     let mut peers = self.peers.write();
-                    if !peers.remove(&canonical) {
-                        return;
-                    }
-                }
+                    peers.remove(&canonical)
+                };
 
-                self.update_peer_count();
-                info!("Removed peer: {}", canonical);
+                if removed {
+                    self.update_peer_count();
+                    info!("Removed peer: {}", canonical);
+                }
             }
             Err(e) => {
                 warn!(
@@ -279,13 +380,6 @@ impl HttpP2PNetwork {
                 );
             }
         }
-
-        {
-            let mut count = self.peer_count.write();
-            *count = self.peers.read().len();
-        }
-
-        info!("Removed peer: {}", peer_address);
     }
 
     /// Get message sender for sending messages
@@ -296,6 +390,11 @@ impl HttpP2PNetwork {
     /// Get current peer count
     pub fn get_peer_count(&self) -> usize {
         *self.peer_count.read()
+    }
+
+    fn update_peer_count(&self) {
+        let count = self.peers.read().len();
+        *self.peer_count.write() = count;
     }
 
     /// Get local peer ID
@@ -311,6 +410,22 @@ impl HttpP2PNetwork {
     /// Get list of peers
     pub fn get_peers(&self) -> Vec<String> {
         self.peers.read().iter().cloned().collect()
+    }
+
+    /// Get the address advertised to other peers
+    pub fn get_announce_address(&self) -> String {
+        self.announce_address.read().clone()
+    }
+
+    /// Queue a peer info announcement for the network
+    pub fn announce_self(&self) -> Result<()> {
+        let address = self.get_announce_address();
+        let message = NetworkMessage::PeerInfo {
+            peer_id: self.local_peer_id.clone(),
+            addresses: vec![address],
+        };
+        self.message_sender.send(message)?;
+        Ok(())
     }
 
     /// Broadcast a block to all peers
@@ -343,6 +458,7 @@ impl HttpP2PNetwork {
         message: NetworkMessage,
     ) {
         let peer_list = peers.read().clone();
+        let local_address = announce_address.read().clone();
 
         for peer_address in peer_list {
             if peer_address == local_address {
@@ -420,27 +536,25 @@ impl HttpP2PNetwork {
         client: &Client,
         peers: &Arc<parking_lot::RwLock<HashSet<String>>>,
         local_address: &str,
-    ) {
+        peer_count: &Arc<parking_lot::RwLock<usize>>,
+    ) -> Result<()> {
         let peer_list = peers.read().clone();
 
         for peer_address in peer_list {
-            let client = client.clone();
-            let peers = peers.clone();
-            let local_address = local_address.to_string();
-
-            tokio::spawn(async move {
-                if let Err(e) = Self::request_peers_from_peer(
-                    &client,
-                    &peer_address,
-                    &peers,
-                    &local_address,
-                )
-                .await
-                {
-                    debug!("Failed to discover peers from {}: {}", peer_address, e);
-                }
-            });
+            if let Err(e) = Self::request_peers_from_peer(
+                client,
+                &peer_address,
+                peers,
+                local_address,
+                peer_count,
+            )
+            .await
+            {
+                debug!("Failed to discover peers from {}: {}", peer_address, e);
+            }
         }
+
+        Ok(())
     }
 
     /// Request peer list from a specific peer
@@ -457,17 +571,255 @@ impl HttpP2PNetwork {
         if response.status().is_success() {
             let peer_list: Vec<String> = response.json().await?;
 
-            // Add new peers (excluding ourselves)
-            let mut current_peers = peers.write();
-            for peer in peer_list {
-                if peer != local_address && !current_peers.contains(&peer) {
-                    current_peers.insert(peer.clone());
-                    info!("Discovered new peer: {}", peer);
+            let mut added = false;
+            {
+                let mut current_peers = peers.write();
+                for peer in peer_list {
+                    match Self::canonicalize_address(&peer) {
+                        Ok(canonical) => {
+                            if canonical != local_address && !current_peers.contains(&canonical) {
+                                current_peers.insert(canonical.clone());
+                                added = true;
+                                info!("Discovered new peer: {}", canonical);
+                            }
+                        }
+                        Err(e) => {
+                            debug!("Skipping invalid peer address {}: {}", peer, e);
+                        }
+                    }
                 }
+            }
+
+            if added {
+                *peer_count.write() = peers.read().len();
             }
         }
 
         Ok(())
+    }
+
+    fn canonicalize_address(address: &str) -> Result<String> {
+        let trimmed = address.trim();
+        if trimmed.is_empty() {
+            return Err(anyhow!("address cannot be empty"));
+        }
+
+        let mut candidates = vec![trimmed.to_string()];
+        if !trimmed.starts_with("http://") && !trimmed.starts_with("https://") {
+            candidates.push(format!("http://{}", trimmed));
+        }
+
+        for candidate in candidates {
+            if let Ok(url) = Url::parse(&candidate) {
+                return Ok(Self::normalize_url(url));
+            }
+        }
+
+        Err(anyhow!("invalid peer address: {}", address))
+    }
+
+    fn normalize_url(mut url: Url) -> String {
+        // Ensure URLs always include a port component
+        if url.port_or_known_default().is_none() {
+            if let Err(e) = url.set_port(Some(80)) {
+                debug!("Failed to normalize URL without port: {}", e);
+            }
+        }
+
+        let mut normalized = url.to_string();
+        while normalized.ends_with('/') {
+            normalized.pop();
+        }
+        normalized
+    }
+
+    fn build_announce_address(scheme: &str, host: &str, port: u16) -> Result<String> {
+        let trimmed = host.trim();
+        if trimmed.is_empty() {
+            return Err(anyhow!("announce host cannot be empty"));
+        }
+
+        let mut url = if trimmed.starts_with("http://") || trimmed.starts_with("https://") {
+            Url::parse(trimmed)?
+        } else {
+            Url::parse(&format!("{}://{}", scheme, trimmed))?
+        };
+
+        if url.port().is_none() {
+            url.set_port(Some(port))
+                .map_err(|_| anyhow!("invalid announce port: {}", port))?;
+        }
+
+        Ok(Self::normalize_url(url))
+    }
+
+    fn store_announce_address(
+        announce_address: &Arc<parking_lot::RwLock<String>>,
+        new_address: String,
+    ) -> Result<()> {
+        let canonical = Self::canonicalize_address(&new_address)?;
+        let mut current = announce_address.write();
+        if *current != canonical {
+            info!("Updated announce address to {}", canonical);
+            *current = canonical;
+        }
+        Ok(())
+    }
+
+    async fn refresh_announce_address_inner(
+        client: &Client,
+        config: &P2PConfig,
+        listen_host: &str,
+        listen_scheme: &str,
+        listen_port: u16,
+        announce_address: &Arc<parking_lot::RwLock<String>>,
+        upnp_mapping_active: &Arc<parking_lot::RwLock<bool>>,
+    ) -> Result<()> {
+        if let Some(public_host) = &config.public_host {
+            let address = Self::build_announce_address(listen_scheme, public_host, listen_port)?;
+            return Self::store_announce_address(announce_address, address);
+        }
+
+        if config.enable_upnp {
+            if let Some(ip) =
+                Self::try_get_upnp_external_ip(listen_port, upnp_mapping_active).await?
+            {
+                let address =
+                    Self::build_announce_address(listen_scheme, &ip.to_string(), listen_port)?;
+                return Self::store_announce_address(announce_address, address);
+            }
+        }
+
+        if let Some(ip) = Self::fetch_external_ip(client, &config.external_ip_services).await? {
+            let address = Self::build_announce_address(listen_scheme, &ip, listen_port)?;
+            return Self::store_announce_address(announce_address, address);
+        }
+
+        let fallback = Self::build_announce_address(listen_scheme, listen_host, listen_port)?;
+        Self::store_announce_address(announce_address, fallback)?;
+        Ok(())
+    }
+
+    async fn fetch_external_ip(client: &Client, services: &[String]) -> Result<Option<String>> {
+        for service in services {
+            let endpoint = service.trim();
+            if endpoint.is_empty() {
+                continue;
+            }
+
+            match client.get(endpoint).send().await {
+                Ok(response) => {
+                    if !response.status().is_success() {
+                        debug!(
+                            "External IP service {} returned status {}",
+                            endpoint,
+                            response.status()
+                        );
+                        continue;
+                    }
+
+                    match response.text().await {
+                        Ok(body) => {
+                            let candidate = body.trim();
+                            if candidate.is_empty() {
+                                continue;
+                            }
+                            if candidate.parse::<IpAddr>().is_ok() {
+                                info!("Detected external IP {} via {}", candidate, endpoint);
+                                return Ok(Some(candidate.to_string()));
+                            } else {
+                                debug!(
+                                    "External IP service {} returned unexpected payload: {}",
+                                    endpoint, candidate
+                                );
+                            }
+                        }
+                        Err(e) => {
+                            debug!(
+                                "Failed to read response from external IP service {}: {}",
+                                endpoint, e
+                            );
+                        }
+                    }
+                }
+                Err(e) => {
+                    debug!("Failed to contact external IP service {}: {}", endpoint, e);
+                }
+            }
+        }
+
+        Ok(None)
+    }
+
+    async fn try_get_upnp_external_ip(
+        listen_port: u16,
+        upnp_mapping_active: &Arc<parking_lot::RwLock<bool>>,
+    ) -> Result<Option<IpAddr>> {
+        match search_gateway(Default::default()).await {
+            Ok(gateway) => {
+                let external_ip = gateway.get_external_ip().await?;
+
+                if !*upnp_mapping_active.read() {
+                    match local_ip() {
+                        Ok(IpAddr::V4(local_ipv4)) => {
+                            let socket = SocketAddrV4::new(local_ipv4, listen_port);
+                            match gateway
+                                .add_port(
+                                    PortMappingProtocol::TCP,
+                                    listen_port,
+                                    socket,
+                                    0,
+                                    "ippan-node",
+                                )
+                                .await
+                            {
+                                Ok(_) => {
+                                    info!("Established UPnP port mapping on port {}", listen_port);
+                                    *upnp_mapping_active.write() = true;
+                                }
+                                Err(e) => {
+                                    warn!("Failed to configure UPnP port mapping: {}", e);
+                                }
+                            }
+                        }
+                        Ok(IpAddr::V6(_)) => {
+                            debug!("Local IPv6 address detected; skipping UPnP mapping");
+                        }
+                        Err(e) => {
+                            debug!("Failed to obtain local IP address for UPnP: {}", e);
+                        }
+                    }
+                }
+
+                Ok(Some(external_ip))
+            }
+            Err(e) => {
+                debug!("UPnP gateway discovery failed: {}", e);
+                Ok(None)
+            }
+        }
+    }
+
+    async fn teardown_upnp_mapping(
+        listen_port: u16,
+        upnp_mapping_active: &Arc<parking_lot::RwLock<bool>>,
+    ) -> Result<()> {
+        if !*upnp_mapping_active.read() {
+            return Ok(());
+        }
+
+        match search_gateway(Default::default()).await {
+            Ok(gateway) => {
+                gateway
+                    .remove_port(PortMappingProtocol::TCP, listen_port)
+                    .await
+                    .map_err(|e| anyhow!("{}", e))?;
+                info!("Removed UPnP port mapping on port {}", listen_port);
+                *upnp_mapping_active.write() = false;
+                Ok(())
+            }
+            Err(e) => Err(anyhow!("failed to contact UPnP gateway: {}", e)),
+        }
     }
 }
 


### PR DESCRIPTION
## Summary
- add configuration knobs to expose public host discovery, UPnP and discovery intervals to the node
- teach the HTTP P2P network to determine a public announce address via UPnP/external IP lookups and periodically broadcast it
- expose helper methods for announcing and reporting the node's public address while hardening peer management bookkeeping

## Testing
- `cargo fmt`
- `cargo check` *(fails: crates/types/src/transaction.rs:56:24: no method named compute_hash)*

------
https://chatgpt.com/codex/tasks/task_e_68d4ecb841d8832b86264456a265ae96