### PR TITLE
Serve unified UI from RPC server

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -949,6 +949,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "http-range-header"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9171a2ea8a68358193d15dd5d70c1c10a2afc3e7e4c5bc92bc9f025cebd7359c"
+
+[[package]]
 name = "httparse"
 version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1472,6 +1478,16 @@ name = "mime"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
+
+[[package]]
+name = "mime_guess"
+version = "2.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7c44f8e672c00fe5308fa235f821cb4198414e1c77935c1ab6948d3fd78550e"
+dependencies = [
+ "mime",
+ "unicase",
+]
 
 [[package]]
 name = "minimal-lexical"
@@ -2629,10 +2645,18 @@ checksum = "1e9cd434a998747dd2c4276bc96ee2e0c7a2eadf3cae88e52be55a05fa9053f5"
 dependencies = [
  "bitflags 2.9.4",
  "bytes",
+ "futures-util",
  "http 1.3.1",
  "http-body 1.0.1",
  "http-body-util",
+ "http-range-header",
+ "httpdate",
+ "mime",
+ "mime_guess",
+ "percent-encoding",
  "pin-project-lite",
+ "tokio",
+ "tokio-util",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -2729,6 +2753,12 @@ name = "ucd-trie"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2896d95c02a80c6d6a5d6e953d479f5ddf2dfdb6a244441010e373ac0fb88971"
+
+[[package]]
+name = "unicase"
+version = "2.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75b844d17643ee918803943289730bec8aac480150456169e647ed0b576ba539"
 
 [[package]]
 name = "unicode-ident"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,7 @@ heapless = "0.8"
 # Production dependencies
 axum = { version = "0.7", features = ["macros", "tracing"] }
 tower = "0.4"
-tower-http = { version = "0.5", features = ["cors", "trace"] }
+tower-http = { version = "0.5", features = ["cors", "trace", "fs"] }
 sled = "0.34"
 libp2p = { version = "0.53", features = ["tcp", "yamux", "noise", "gossipsub", "identify", "ping", "kad"] }
 futures = "0.3"

--- a/README.md
+++ b/README.md
@@ -117,6 +117,8 @@ Features:
 - Network monitoring
 - Validator registration
 
+The Rust RPC server can serve the compiled Unified UI directly. Build the frontend (`npm run build`) so the assets are available in `apps/unified-ui/dist`, or point the node to another build directory using the `IPPAN_UNIFIED_UI_DIST_DIR` environment variable before starting the node.
+
 ## 📊 HashTimer Examples
 
 ### Transaction HashTimer

--- a/apps/unified-ui/README.md
+++ b/apps/unified-ui/README.md
@@ -115,6 +115,11 @@ The built files will be in the `dist` directory.
 
      The server located at `server/serve.js` provides security headers, caches static assets, and returns a 200/`ok` response for health checks.
 
+   - **Serve the build directly from the IPPAN node (optional):**
+     - Place the compiled assets where the Rust node can find them (default: `apps/unified-ui/dist`).
+     - Or point the node at a custom directory via `IPPAN_UNIFIED_UI_DIST_DIR=/path/to/dist`.
+     - When configured, the RPC server will expose the Unified UI at `/` while keeping the `/api` routes available.
+
 3. **Expose the UI Through Your Reverse Proxy**
    - Ensure the domain you will use for the UI is allowed by your reverse proxy. Your previous Envoy configuration returned `Domain forbidden`, which indicates the host header needs to be listed under the allowed domains. The snippets below illustrate the minimal configuration needed for Nginx and Envoy (replace hostnames/IPs with your values):
 


### PR DESCRIPTION
## Summary
- enable the RPC server to serve the compiled Unified UI with tower-http static file support
- add configuration for `IPPAN_UNIFIED_UI_DIST_DIR` (defaulting to `apps/unified-ui/dist`) and log when the UI is enabled
- document how to host the Unified UI from the node and update dependencies accordingly

## Testing
- cargo test -p ippan-rpc


------
https://chatgpt.com/codex/tasks/task_e_68d63cbbe934832b9fb85444f53d3cbe