### PR TITLE
Add CI/CD pipeline for Unified UI deployment

### DIFF
--- a/.github/workflows/ui-build-deploy.yml
+++ b/.github/workflows/ui-build-deploy.yml
@@ -1,0 +1,52 @@
+name: Build & Deploy Unified UI
+
+on:
+  push:
+    branches: [ main ]
+    paths:
+      - 'apps/unified-ui/**'
+      - '.github/workflows/ui-build-deploy.yml'
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build UI image
+        run: |
+          cd apps/unified-ui
+          docker build -t ghcr.io/${{ github.repository_owner }}/ippan-unified-ui:latest .
+
+      - name: Push UI image
+        run: docker push ghcr.io/${{ github.repository_owner }}/ippan-unified-ui:latest
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    if: github.ref == 'refs/heads/main'
+    steps:
+      - name: SSH deploy (pull & up)
+        uses: appleboy/ssh-action@v1.0.3
+        with:
+          host: ${{ secrets.SERVER_HOST }}
+          username: ${{ secrets.SERVER_USER }}
+          key: ${{ secrets.SERVER_SSH_KEY }}
+          script: |
+            mkdir -p /srv/ippan
+            docker login ghcr.io -u ${{ github.actor }} -p ${{ secrets.GITHUB_TOKEN }}
+            docker pull ghcr.io/${{ github.repository_owner }}/ippan-unified-ui:latest
+            cd /srv/ippan
+            docker compose up -d
+            curl -fsS http://127.0.0.1:4000/api/health || (docker logs $(docker ps -q --filter name=ippan-ui) && exit 1)

--- a/.gitignore
+++ b/.gitignore
@@ -105,7 +105,7 @@ jspm_packages/
 # dotenv environment variables file
 .env
 .env.test
-.env.production
+!.env.production
 .env.local
 .env.development.local
 .env.test.local

--- a/apps/unified-ui/.env.production
+++ b/apps/unified-ui/.env.production
@@ -1,0 +1,8 @@
+# public (browser)
+NEXT_PUBLIC_API_BASE_URL=https://api.ippan.org
+NEXT_PUBLIC_WS_URL=wss://api.ippan.org/ws
+NEXT_PUBLIC_NETWORK_NAME=IPPAN-Devnet
+
+# runtime
+NODE_ENV=production
+PORT=4000

--- a/apps/unified-ui/Dockerfile
+++ b/apps/unified-ui/Dockerfile
@@ -1,40 +1,30 @@
-# IPPAN Unified UI - Multi-stage Docker build
-FROM node:20-alpine as builder
+# Unified UI production image
+FROM node:20-alpine AS builder
 
-# Set working directory
 WORKDIR /app
 
-# Copy package files
-COPY package*.json ./
+COPY package.json pnpm-lock.yaml* package-lock.json* yarn.lock* ./
 
-# Install dependencies
-RUN npm ci --only=production
+RUN corepack enable || true
+RUN [ -f pnpm-lock.yaml ] && pnpm install --frozen-lockfile || \
+    ([ -f package-lock.json ] && npm ci || \
+     ([ -f yarn.lock ] && yarn install || npm install))
 
-# Copy source code
 COPY . .
 
-# Build the application
-RUN npm run build
+ENV NODE_ENV=production
 
-# Production stage
-FROM nginx:alpine
+RUN npm run build || pnpm build || yarn build
 
-# Copy built application
-COPY --from=builder /app/dist /usr/share/nginx/html
+FROM node:20-alpine AS runner
 
-# Copy nginx configuration
-COPY nginx.conf /etc/nginx/conf.d/default.conf
+WORKDIR /app
 
-# Create nginx user directories
-RUN mkdir -p /var/cache/nginx/client_temp && \
-    chown -R nginx:nginx /var/cache/nginx
+ENV NODE_ENV=production
+ENV PORT=4000
 
-# Expose port
-EXPOSE 80
+COPY --from=builder /app ./
 
-# Health check
-HEALTHCHECK --interval=30s --timeout=3s --start-period=5s --retries=3 \
-    CMD curl -f http://localhost/ || exit 1
+EXPOSE 4000
 
-# Start nginx
-CMD ["nginx", "-g", "daemon off;"]
+CMD ["npm", "run", "start"]


### PR DESCRIPTION
## Summary
- add production environment defaults for the Unified UI and ensure they are tracked in git
- update the Unified UI Dockerfile to a two-stage Node-based image compatible with pnpm/yarn/npm builds
- configure a GitHub Actions workflow to build, push, and deploy the Unified UI container on pushes to main

## Testing
- npm run build (from apps/unified-ui)


------
https://chatgpt.com/codex/tasks/task_e_68d641452440832bbec1a35911440024