### PR TITLE
Run cargo fmt

### DIFF
--- a/crates/p2p/src/lib.rs
+++ b/crates/p2p/src/lib.rs
@@ -34,10 +34,17 @@ pub enum P2PError {
 pub enum NetworkMessage {
     Block(Block),
     Transaction(Transaction),
-    BlockRequest { hash: [u8; 32] },
+    BlockRequest {
+        hash: [u8; 32],
+    },
     BlockResponse(Block),
-    PeerInfo { peer_id: String, addresses: Vec<String> },
-    PeerDiscovery { peers: Vec<String> },
+    PeerInfo {
+        peer_id: String,
+        addresses: Vec<String>,
+    },
+    PeerDiscovery {
+        peers: Vec<String>,
+    },
 }
 
 /// Peer information

--- a/crates/rpc/src/lib.rs
+++ b/crates/rpc/src/lib.rs
@@ -37,10 +37,17 @@ pub enum P2PError {
 pub enum NetworkMessage {
     Block(Block),
     Transaction(Transaction),
-    BlockRequest { hash: [u8; 32] },
+    BlockRequest {
+        hash: [u8; 32],
+    },
     BlockResponse(Block),
-    PeerInfo { peer_id: String, addresses: Vec<String> },
-    PeerDiscovery { peers: Vec<String> },
+    PeerInfo {
+        peer_id: String,
+        addresses: Vec<String>,
+    },
+    PeerDiscovery {
+        peers: Vec<String>,
+    },
 }
 
 /// Peer information

--- a/crates/types/src/address.rs
+++ b/crates/types/src/address.rs
@@ -115,6 +115,6 @@ mod tests {
     fn invalid_hex_rejected() {
         let bad = format!("i{}", "gg".repeat(ADDRESS_BYTES));
         let err = decode_address(&bad).unwrap_err();
-        assert!(matches!(err, AddressError::InvalidHex(_))); 
+        assert!(matches!(err, AddressError::InvalidHex(_)));
     }
 }

--- a/crates/types/src/transaction.rs
+++ b/crates/types/src/transaction.rs
@@ -120,7 +120,9 @@ impl Transaction {
         match VerifyingKey::from_bytes(&self.from) {
             Ok(verifying_key) => {
                 let signature = Signature::from_bytes(&self.signature);
-                verifying_key.verify(&self.message_bytes(), &signature).is_ok()
+                verifying_key
+                    .verify(&self.message_bytes(), &signature)
+                    .is_ok()
             }
             Err(_) => false,
         }


### PR DESCRIPTION
## Summary
- reformat the NetworkMessage enums so their struct variants span multiple lines per rustfmt
- wrap the transaction signature verification call to follow standard rustfmt line breaks

## Testing
- cargo fmt --all -- --check
- cargo test

------
https://chatgpt.com/codex/tasks/task_e_68d654d9638c832bab2c8be7cde7172f