### PR TITLE
Add default Envoy config for unified UI

### DIFF
--- a/deploy/unified-ui-deployment.md
+++ b/deploy/unified-ui-deployment.md
@@ -64,6 +64,20 @@ server {
 ```
 
 For Envoy-based setups, ensure the virtual host configuration includes the incoming domain or use `"*"` to accept all hosts.
+The repository now ships with a ready-to-use configuration at
+`deployments/envoy/envoy.yaml` that binds Envoy to port `80`, proxies traffic to
+the UI container listening on `4000`, and permits any `Host` header. Deploy it
+alongside the UI container to avoid the `Domain forbidden` responses that occur
+when the requested host is missing from the Envoy allow list:
+
+```bash
+docker run --rm -v "$PWD/deployments/envoy/envoy.yaml:/etc/envoy/envoy.yaml" \
+  --network host envoyproxy/envoy:v1.31-latest
+```
+
+If you need to restrict accepted domains later, replace the wildcard entry in
+`domains:` with an explicit list of hostnames while keeping the UI upstream
+settings intact.
 
 ## 4. Verify deployments
 1. Push a change under `apps/unified-ui/**`. The workflow builds and pushes a new image to GHCR, then deploys it to the server.

--- a/deployments/envoy/envoy.yaml
+++ b/deployments/envoy/envoy.yaml
@@ -1,0 +1,61 @@
+static_resources:
+  listeners:
+    - name: unified_ui_listener
+      address:
+        socket_address:
+          address: 0.0.0.0
+          port_value: 80
+      filter_chains:
+        - filters:
+            - name: envoy.filters.network.http_connection_manager
+              typed_config:
+                "@type": type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
+                stat_prefix: ingress_http
+                request_headers_to_add:
+                  - header:
+                      key: X-Forwarded-Proto
+                      value: "http"
+                    append_action: APPEND_IF_EXISTS_OR_ADD
+                route_config:
+                  name: unified_ui_route
+                  virtual_hosts:
+                    - name: unified_ui
+                      domains:
+                        - "*"
+                      routes:
+                        - match:
+                            prefix: "/api/health"
+                          route:
+                            cluster: unified_ui_upstream
+                        - match:
+                            prefix: "/"
+                          route:
+                            cluster: unified_ui_upstream
+                            timeout: 15s
+                http_filters:
+                  - name: envoy.filters.http.router
+  clusters:
+    - name: unified_ui_upstream
+      connect_timeout: 1s
+      type: logical_dns
+      load_assignment:
+        cluster_name: unified_ui_upstream
+        endpoints:
+          - lb_endpoints:
+              - endpoint:
+                  address:
+                    socket_address:
+                      address: 127.0.0.1
+                      port_value: 4000
+      health_checks:
+        - timeout: 2s
+          interval: 5s
+          unhealthy_threshold: 3
+          healthy_threshold: 1
+          http_health_check:
+            path: /api/health
+admin:
+  address:
+    socket_address:
+      address: 127.0.0.1
+      port_value: 19000


### PR DESCRIPTION
## Summary
- add a ready-to-use Envoy configuration that accepts any host header and proxies unified UI traffic to the local container
- document how to run the bundled Envoy config so deployments avoid the "Domain forbidden" response

## Testing
- not run (docs and configuration only)


------
https://chatgpt.com/codex/tasks/task_e_68d65780257c832ba14097c2b4282833