### PR TITLE
Add validator API endpoint and hook up validators page

### DIFF
--- a/apps/unified-ui/src/lib/api.ts
+++ b/apps/unified-ui/src/lib/api.ts
@@ -242,6 +242,13 @@ export interface ConsensusStats {
   consensus_status: string;
 }
 
+export interface ValidatorInfo {
+  node_id: string;
+  address: string;
+  stake_amount: number;
+  is_active: boolean;
+}
+
 // Node Status API
 export async function getNodeStatus(): Promise<NodeStatus> {
   const response = await api.get('/api/v1/status');
@@ -263,6 +270,11 @@ export async function getMempoolStats(): Promise<MempoolStats> {
 // Consensus API
 export async function getConsensusStats(): Promise<ConsensusStats> {
   const response = await api.get('/api/v1/consensus');
+  return response.data;
+}
+
+export async function getValidators(): Promise<ValidatorInfo[]> {
+  const response = await api.get('/api/v1/validators');
   return response.data;
 }
 

--- a/apps/unified-ui/src/pages/explorer/ValidatorsPage.tsx
+++ b/apps/unified-ui/src/pages/explorer/ValidatorsPage.tsx
@@ -1,66 +1,67 @@
-import { useState, useEffect } from 'react'
+import { useEffect, useMemo, useState } from 'react'
+import { useQuery } from '@tanstack/react-query'
 import { Card, Button, Badge, LoadingSpinner } from '../../components/UI'
 import ValidatorRegistrationModal from '../../components/ValidatorRegistrationModal'
 import { ToastContainer, useToast } from '../../components/Toast'
-
-interface Validator {
-  address: string
-  name: string
-  status: 'active' | 'inactive' | 'slashed'
-  stakedAmount: string
-  commission: number
-  uptime: number
-  blocksProduced: number
-  lastBlock: string
-  performance: number
-}
+import { getConsensusStats, getValidators, ValidatorInfo } from '../../lib/api'
 
 export default function ValidatorsPage() {
-  const [validators, setValidators] = useState<Validator[]>([])
-  const [isLoading, setIsLoading] = useState(true)
   const [isRegistrationModalOpen, setIsRegistrationModalOpen] = useState(false)
-  const { toasts, removeToast, success, error } = useToast()
+  const { toasts, removeToast, success, error: showError } = useToast()
+
+  const validatorsQuery = useQuery({
+    queryKey: ['validators'],
+    queryFn: getValidators,
+  })
+
+  const consensusQuery = useQuery({
+    queryKey: ['consensus'],
+    queryFn: getConsensusStats,
+  })
 
   useEffect(() => {
-    const mockValidators: Validator[] = [
-      {
-        address: '0xValidator1...',
-        name: 'Validator Alpha',
-        status: 'active',
-        stakedAmount: '50,000 IPPAN',
-        commission: 5.0,
-        uptime: 99.8,
-        blocksProduced: 1234,
-        lastBlock: new Date().toISOString(),
-        performance: 98.5
-      },
-      {
-        address: '0xValidator2...',
-        name: 'Validator Beta',
-        status: 'active',
-        stakedAmount: '45,000 IPPAN',
-        commission: 3.5,
-        uptime: 99.9,
-        blocksProduced: 1189,
-        lastBlock: new Date(Date.now() - 300000).toISOString(),
-        performance: 99.2
-      },
-      {
-        address: '0xValidator3...',
-        name: 'Validator Gamma',
-        status: 'inactive',
-        stakedAmount: '30,000 IPPAN',
-        commission: 4.0,
-        uptime: 85.2,
-        blocksProduced: 567,
-        lastBlock: new Date(Date.now() - 3600000).toISOString(),
-        performance: 75.8
-      }
-    ]
+    if (!validatorsQuery.isError) {
+      return
+    }
 
-    setValidators(mockValidators)
-    setIsLoading(false)
-  }, [])
+    const message =
+      validatorsQuery.error instanceof Error
+        ? validatorsQuery.error.message
+        : 'Unable to load validators'
+
+    showError('Failed to load validators', message)
+  }, [validatorsQuery.isError, validatorsQuery.error, showError])
+
+  const validators: ValidatorInfo[] = validatorsQuery.data ?? []
+
+  const numberFormatter = useMemo(
+    () => new Intl.NumberFormat(undefined, { maximumFractionDigits: 2 }),
+    []
+  )
+
+  const totals = useMemo(() => {
+    if (!validators.length) {
+      return {
+        active: 0,
+        inactive: 0,
+        totalStake: 0,
+        averageStake: 0,
+      }
+    }
+
+    const active = validators.filter(v => v.is_active).length
+    const inactive = validators.length - active
+    const totalStake = validators.reduce((sum, v) => sum + v.stake_amount, 0)
+
+    return {
+      active,
+      inactive,
+      totalStake,
+      averageStake: totalStake / validators.length,
+    }
+  }, [validators])
+
+  const formatStake = (amount: number) => `${numberFormatter.format(amount)} IPN`
 
   const handleRegistrationSuccess = () => {
     success(
@@ -68,15 +69,30 @@ export default function ValidatorsPage() {
       'Your validator registration has been submitted and is being processed. You will be notified once it becomes active.',
       8000
     )
-    
-    // In a real app, you might want to refresh the validators list here
-    // fetchValidators()
+
+    void validatorsQuery.refetch()
   }
 
-  if (isLoading) {
+  if (validatorsQuery.isLoading) {
     return (
       <div className="flex justify-center items-center h-64">
         <LoadingSpinner />
+      </div>
+    )
+  }
+
+  if (validatorsQuery.isError) {
+    const message =
+      validatorsQuery.error instanceof Error
+        ? validatorsQuery.error.message
+        : 'Unable to load validators'
+
+    return (
+      <div className="space-y-4">
+        <h1 className="text-2xl font-bold text-gray-900">Validators</h1>
+        <Card>
+          <div className="text-sm text-red-600">{message}</div>
+        </Card>
       </div>
     )
   }
@@ -88,35 +104,35 @@ export default function ValidatorsPage() {
         <Badge variant="success">Live Network</Badge>
       </div>
 
-      <Card title="Active Validators">
-        <div className="space-y-4">
-          {validators.map((validator) => (
-            <div key={validator.address} className="p-4 border rounded-lg">
-              <div className="flex justify-between items-start">
-                <div className="flex-1">
-                  <div className="flex items-center space-x-2 mb-2">
-                    <h3 className="font-semibold">{validator.name}</h3>
-                    <Badge variant={validator.status === 'active' ? 'success' : validator.status === 'inactive' ? 'warning' : 'error'}>
-                      {validator.status}
-                    </Badge>
+      <Card title="Validator Set">
+        {validators.length === 0 ? (
+          <div className="text-sm text-gray-600">No validators are currently registered.</div>
+        ) : (
+          <div className="space-y-4">
+            {validators.map((validator) => (
+              <div key={validator.node_id} className="p-4 border rounded-lg">
+                <div className="flex justify-between items-start">
+                  <div className="flex-1">
+                    <div className="flex items-center space-x-2 mb-2">
+                      <h3 className="font-semibold">{validator.node_id.slice(0, 12)}…</h3>
+                      <Badge variant={validator.is_active ? 'success' : 'warning'}>
+                        {validator.is_active ? 'active' : 'inactive'}
+                      </Badge>
+                    </div>
+                    <div className="text-sm text-gray-600 space-y-1">
+                      <div>Node ID: {validator.node_id}</div>
+                      <div>Address: {validator.address}</div>
+                    </div>
                   </div>
-                  <div className="text-sm text-gray-600 space-y-1">
-                    <div>Address: {validator.address}</div>
-                    <div>Staked: {validator.stakedAmount}</div>
-                    <div>Commission: {validator.commission}%</div>
-                    <div>Uptime: {validator.uptime}%</div>
+                  <div className="text-right text-sm text-gray-600">
+                    <div className="text-lg font-bold text-green-600">{formatStake(validator.stake_amount)}</div>
+                    <div>Total Stake</div>
                   </div>
-                </div>
-                <div className="text-right text-sm text-gray-600">
-                  <div className="text-lg font-bold">{validator.performance}%</div>
-                  <div>Performance</div>
-                  <div>{validator.blocksProduced} blocks</div>
-                  <div>{new Date(validator.lastBlock).toLocaleTimeString()}</div>
                 </div>
               </div>
-            </div>
-          ))}
-        </div>
+            ))}
+          </div>
+        )}
       </Card>
 
       <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
@@ -127,58 +143,54 @@ export default function ValidatorsPage() {
               <div className="text-sm text-gray-600">Total Validators</div>
             </div>
             <div className="text-center">
-              <div className="text-3xl font-bold text-green-600">
-                {validators.filter(v => v.status === 'active').length}
-              </div>
+              <div className="text-3xl font-bold text-green-600">{totals.active}</div>
               <div className="text-sm text-gray-600">Active</div>
             </div>
             <div className="text-center">
-              <div className="text-3xl font-bold text-yellow-600">
-                {validators.filter(v => v.status === 'inactive').length}
-              </div>
+              <div className="text-3xl font-bold text-yellow-600">{totals.inactive}</div>
               <div className="text-sm text-gray-600">Inactive</div>
             </div>
           </div>
         </Card>
 
-        <Card title="Performance Metrics">
-          <div className="space-y-4">
-            <div>
-              <label className="block text-sm font-medium text-gray-700">Average Uptime</label>
-              <div className="text-2xl font-bold text-green-600">
-                {(validators.reduce((sum, v) => sum + v.uptime, 0) / validators.length).toFixed(1)}%
+        <Card title="Consensus Overview">
+          {consensusQuery.isLoading ? (
+            <div className="flex justify-center py-6">
+              <LoadingSpinner />
+            </div>
+          ) : consensusQuery.isError ? (
+            <div className="text-sm text-red-600">Unable to load consensus details</div>
+          ) : consensusQuery.data ? (
+            <div className="space-y-4">
+              <div>
+                <label className="block text-sm font-medium text-gray-700">Current Round</label>
+                <div className="text-2xl font-bold text-blue-600">{consensusQuery.data.current_round.toLocaleString()}</div>
+              </div>
+              <div>
+                <label className="block text-sm font-medium text-gray-700">Latest Block Height</label>
+                <div className="text-2xl font-bold text-purple-600">{consensusQuery.data.block_height.toLocaleString()}</div>
+              </div>
+              <div>
+                <label className="block text-sm font-medium text-gray-700">Consensus Status</label>
+                <div className="text-2xl font-bold text-green-600 capitalize">{consensusQuery.data.consensus_status}</div>
               </div>
             </div>
-            <div>
-              <label className="block text-sm font-medium text-gray-700">Average Performance</label>
-              <div className="text-2xl font-bold text-blue-600">
-                {(validators.reduce((sum, v) => sum + v.performance, 0) / validators.length).toFixed(1)}%
-              </div>
-            </div>
-            <div>
-              <label className="block text-sm font-medium text-gray-700">Total Blocks</label>
-              <div className="text-2xl font-bold text-purple-600">
-                {validators.reduce((sum, v) => sum + v.blocksProduced, 0).toLocaleString()}
-              </div>
-            </div>
-          </div>
+          ) : (
+            <div className="text-sm text-gray-600">Consensus data unavailable.</div>
+          )}
         </Card>
 
         <Card title="Staking Overview">
           <div className="space-y-4">
             <div>
               <label className="block text-sm font-medium text-gray-700">Total Staked</label>
-              <div className="text-2xl font-bold text-green-600">
-                {validators.reduce((sum, v) => sum + parseFloat(v.stakedAmount.replace(/[^\d.]/g, '')), 0).toLocaleString()} IPPAN
-              </div>
+              <div className="text-2xl font-bold text-green-600">{formatStake(totals.totalStake)}</div>
             </div>
             <div>
-              <label className="block text-sm font-medium text-gray-700">Average Commission</label>
-              <div className="text-2xl font-bold text-orange-600">
-                {(validators.reduce((sum, v) => sum + v.commission, 0) / validators.length).toFixed(1)}%
-              </div>
+              <label className="block text-sm font-medium text-gray-700">Average Stake</label>
+              <div className="text-2xl font-bold text-orange-600">{formatStake(totals.averageStake)}</div>
             </div>
-            <Button 
+            <Button
               className="w-full"
               onClick={() => setIsRegistrationModalOpen(true)}
             >


### PR DESCRIPTION
## Summary
- expose a new `/api/v1/validators` endpoint that returns the validator set from the consensus engine
- add a typed API client helper and update the validators explorer page to load live data via TanStack Query
- refresh the page layout to show consensus metrics and real stake totals instead of hard-coded mock data

## Testing
- cargo test
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d6e62e7b2c832b88ba11f7234ddd61