### PR TITLE
Fix manual patch workflow branch handling

### DIFF
--- a/.github/workflows/apply-patch-manual.yml
+++ b/.github/workflows/apply-patch-manual.yml
@@ -48,11 +48,11 @@ jobs:
           git config user.name "ippan-auto-bot"
           git config user.email "actions@users.noreply.github.com"
 
-      - name: Create branch
+      - name: Create working branch
         run: |
-          BR="auto/manual-$(date +%Y%m%d-%H%M%S)"
-          echo "BRANCH=$BR" >> $GITHUB_ENV
-          git checkout -b "$BR"
+          BRANCH="auto/manual-$(date +%Y%m%d-%H%M%S)"
+          echo "BRANCH=$BRANCH" >> $GITHUB_ENV
+          git checkout -b "$BRANCH"
 
       - name: Apply patch if present
         if: steps.writepatch.outputs.has_patch == 'true'
@@ -84,28 +84,29 @@ jobs:
           git add -A
 
       - name: Commit changes (if any)
+        id: commit
         run: |
           if git diff --cached --quiet; then
+            echo "made_commit=false" >> $GITHUB_OUTPUT
             echo "No changes staged; nothing to commit."
             exit 0
           fi
           git commit -m "Apply manual patch / cleanup"
+          echo "made_commit=true" >> $GITHUB_OUTPUT
 
       - name: Push branch (if any commit)
+        if: steps.commit.outputs.made_commit == 'true'
         run: |
-          if git log -1 --pretty=%B | grep -q "Apply manual patch / cleanup"; then
-            git push -u origin "$BRANCH"
-          else
-            echo "No commit created; skipping push."
-          fi
+          git push -u origin "$BRANCH"
 
       - name: Open PR (if branch pushed)
         id: cpr
-        if: success()
+        if: steps.commit.outputs.made_commit == 'true'
         uses: peter-evans/create-pull-request@v6
         with:
           token: ${{ github.token }}
           branch: ${{ env.BRANCH }}
+          base: ${{ github.event.repository.default_branch }}
           title: "Apply manual patch / cleanup"
           body: |
             Automated PR created via workflow_dispatch.


### PR DESCRIPTION
## Summary
- ensure the manual patch workflow reuses the same branch variable for creation, push, and PR steps
- add commit detection gates and explicit base branch configuration before opening a PR

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d77be7b050832b903f1eeb5a824b8d