### PR TITLE
Harden Apply Patch From Issue workflow

### DIFF
--- a/.github/workflows/apply-patch-from-issue.yml
+++ b/.github/workflows/apply-patch-from-issue.yml
@@ -25,6 +25,11 @@ jobs:
           token: ${{ github.token }}
           ref: ${{ github.event.repository.default_branch }}
 
+      - name: Debug default/base/head
+        run: |
+          echo "default_branch=${{ github.event.repository.default_branch }}"
+          echo "labels=${{ toJson(github.event.issue.labels.*.name) }}"
+
       - name: Extract patch from issue body (or allow cleanup-only)
         id: extract
         env:
@@ -125,6 +130,12 @@ jobs:
             This PR was created by the Apply Patch From Issue workflow.
           commit-message: "Apply patch / cleanup from #${{ github.event.issue.number }}"
           labels: auto-patch
+
+      - name: Safety: cancel if base==head (should never happen)
+        if: steps.cpr.outputs.pull-request-number == '' || env.BRANCH == github.event.repository.default_branch
+        run: |
+          echo "::warning::PR not opened or base=head detected. BRANCH=$BRANCH base=${{ github.event.repository.default_branch }}"
+          exit 0
 
       - name: Enable auto-merge (label: automerge)
         if: contains(github.event.issue.labels.*.name, 'automerge') && steps.cpr.outputs['pull-request-number'] != ''


### PR DESCRIPTION
## Summary
- add debugging output to capture the default branch and labels before running automation
- gracefully handle scenarios where the pull request base matches the generated branch to avoid failures

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d77dffc17c832bbbbae96ceb830afd