### PR TITLE
Fix Apply Patch workflow encoding issues

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,5 +1,4 @@
-* text=auto
-*.sh    text eol=lf
-*.yml   text eol=lf
-*.yaml  text eol=lf
-Dockerfile text eol=lf
+# normalize text + enforce LF
+* text=auto eol=lf
+*.yml  text eol=lf
+*.yaml text eol=lf

--- a/.github/workflows/apply-patch-from-issue.yml
+++ b/.github/workflows/apply-patch-from-issue.yml
@@ -52,11 +52,6 @@ jobs:
               f.write(patch)
           PY
 
-      - name: Debug - show event and labels
-        run: |
-          echo "event: ${{ github.event_name }}"
-          echo "labels: ${{ toJson(github.event.issue.labels.*.name) }}"
-
       - name: Configure Git
         run: |
           git config user.name "ippan-auto-bot"
@@ -130,12 +125,6 @@ jobs:
             This PR was created by the Apply Patch From Issue workflow.
           commit-message: "Apply patch / cleanup from #${{ github.event.issue.number }}"
           labels: auto-patch
-
-      - name: Safety: cancel if base==head (should never happen)
-        if: steps.cpr.outputs.pull-request-number == '' || env.BRANCH == github.event.repository.default_branch
-        run: |
-          echo "::warning::PR not opened or base=head detected. BRANCH=$BRANCH base=${{ github.event.repository.default_branch }}"
-          exit 0
 
       - name: Enable auto-merge (label: automerge)
         if: contains(github.event.issue.labels.*.name, 'automerge') && steps.cpr.outputs['pull-request-number'] != ''


### PR DESCRIPTION
## Summary
- add a repository-level .gitattributes guard to enforce LF line endings for YAML files
- replace the apply-patch-from-issue workflow with the cleaned, ASCII-only version to resolve the syntax error banner

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d77f90176c832bbbb9dee96e95b828