### PR TITLE
Fix clippy lint in PoA consensus test

### DIFF
--- a/crates/consensus/src/lib.rs
+++ b/crates/consensus/src/lib.rs
@@ -567,7 +567,7 @@ mod tests {
 
         let mut slot = 0u64;
         let mut produced_blocks = 0u64;
-        while mempool_one.read().len() > 0 || mempool_two.read().len() > 0 {
+        while !mempool_one.read().is_empty() || !mempool_two.read().is_empty() {
             let proposer = PoAConsensus::get_proposer_for_slot(&validators, slot).unwrap();
             if proposer == validator_one {
                 PoAConsensus::propose_block(


### PR DESCRIPTION
## Summary
- replace the PoA consensus test's manual `len() > 0` checks with `is_empty()` to satisfy clippy's len-zero lint

## Testing
- cargo clippy --workspace --all-targets --all-features -- -D warnings

------
https://chatgpt.com/codex/tasks/task_e_68d7899d54d4832bb33fc29b2f308485