### PR TITLE
Fix apply-patch workflow syntax and trigger

### DIFF
--- a/.github/workflows/apply-patch-from-issue.yml
+++ b/.github/workflows/apply-patch-from-issue.yml
@@ -15,7 +15,7 @@ permissions:
 
 jobs:
   apply:
-    if: contains(github.event.issue.labels.*.name, 'auto-patch')
+    if: contains(github.event.issue.labels.*.name, 'codex')
     runs-on: ubuntu-latest
 
     steps:
@@ -66,12 +66,15 @@ jobs:
         run: |
           set -e
           if [ -s change.patch ]; then
-            git apply --index --3way change.patch || (echo "::warning::3-way failed; trying without 3-way" && git apply --index change.patch)
+            if ! git apply --index --3way change.patch; then
+              echo "::warning::3-way failed; trying without 3-way"
+              git apply --index change.patch
+            fi
           else
             echo "No patch provided; proceeding to optional cleanup."
           fi
 
-      - name: Remove mock/demo code (label: cleanup-now)
+      - name: "Remove mock/demo code (label: cleanup-now)"
         if: contains(github.event.issue.labels.*.name, 'cleanup-now')
         shell: bash
         run: |
@@ -125,7 +128,7 @@ jobs:
           commit-message: "Apply patch / cleanup from #${{ github.event.issue.number }}"
           labels: auto-patch
 
-      - name: Enable auto-merge (label: automerge)
+      - name: "Enable auto-merge (label: automerge)"
         if: contains(github.event.issue.labels.*.name, 'automerge') && steps.cpr.outputs['pull-request-number'] != ''
         uses: peter-evans/enable-pull-request-automerge@v3
         with:


### PR DESCRIPTION
## Summary
- adjust the apply-patch workflow to trigger on the `codex` label so Issue #66 can launch it
- rewrite the patch application step to avoid YAML parsing issues and quote step names that include colons

## Testing
- python -c "import yaml, sys; yaml.safe_load(open('.github/workflows/apply-patch-from-issue.yml'))"
- yamllint -d "{extends: default, rules: {line-length: disable, truthy: disable, document-start: disable}}" .github/workflows/apply-patch-from-issue.yml

------
https://chatgpt.com/codex/tasks/task_e_68d792a8dd04832b8446dfbc2cf1228c