### PR TITLE
Fix workflow yamllint violations

### DIFF
--- a/.github/workflows/apply-patch-from-issue.yml
+++ b/.github/workflows/apply-patch-from-issue.yml
@@ -1,6 +1,7 @@
+---
 name: Apply Patch From Issue
 
-on:
+"on":
   issues:
     types: [opened, edited, reopened, labeled]
 

--- a/.github/workflows/chatops-apply-patch.yml
+++ b/.github/workflows/chatops-apply-patch.yml
@@ -1,6 +1,7 @@
+---
 name: ChatOps - Apply Patch
 
-on:
+"on":
   issue_comment:
     types: [created, edited]
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,6 @@
+---
 name: CI
-on: [push, pull_request]
+"on": [push, pull_request]
 jobs:
   rust:
     runs-on: ubuntu-latest
@@ -9,7 +10,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
-        with: { components: clippy,rustfmt }
+        with:
+          components: clippy,rustfmt
       - uses: actions/cache@v4
         with:
           path: |

--- a/.github/workflows/triage.yml
+++ b/.github/workflows/triage.yml
@@ -1,5 +1,6 @@
+---
 name: Auto-label & triage
-on:
+"on":
   issues:
     types: [opened, edited, reopened]
 jobs:

--- a/.github/workflows/yamllint.yml
+++ b/.github/workflows/yamllint.yml
@@ -1,5 +1,6 @@
+---
 name: Lint YAML (workflows)
-on:
+"on":
   pull_request:
     paths: [".github/workflows/*.y*ml"]
   push:

--- a/.yamllint.yml
+++ b/.yamllint.yml
@@ -1,0 +1,9 @@
+extends: default
+
+rules:
+  document-start: enable
+  line-length:
+    max: 200
+    level: warning
+  truthy:
+    check-keys: false


### PR DESCRIPTION
## Summary
- add a repo yamllint configuration to relax line length severity and allow workflow `on` keys
- add document start markers and quoted `on` keys across GitHub Actions workflows
- expand the Rust toolchain component mapping to satisfy yamllint style checks

## Testing
- `yamllint -c .yamllint.yml .github/workflows`


------
https://chatgpt.com/codex/tasks/task_e_68d79befa28c832bbc090f3355506fee