### PR TITLE
Expose full unified UI navigation

### DIFF
--- a/apps/unified-ui/src/App.tsx
+++ b/apps/unified-ui/src/App.tsx
@@ -1,7 +1,30 @@
 import { useEffect, useMemo, useState } from 'react'
 import { Routes, Route, NavLink, Navigate } from 'react-router-dom'
 import WalletOverview from './pages/WalletOverview'
+import WalletPage from './pages/WalletPage'
+import PaymentsPage from './pages/PaymentsPage'
+import PaymentsM2M from './pages/PaymentsM2M'
 import DashboardPage from './pages/DashboardPage'
+import StakingPage from './pages/StakingPage'
+import StakingValidator from './pages/StakingValidator'
+import DomainsPage from './pages/DomainsPage'
+import DomainUpdatesPage from './pages/DomainUpdatesPage'
+import InteroperabilityPage from './pages/InteroperabilityPage'
+import StoragePage from './pages/StoragePage'
+import FileAvailabilityPage from './pages/FileAvailabilityPage'
+import NeuralModels from './pages/NeuralModels'
+import ModelsPage from './pages/ModelsPage'
+import DatasetsPage from './pages/DatasetsPage'
+import InferencePage from './pages/InferencePage'
+import BidsPage from './pages/BidsPage'
+import ProofsPage from './pages/ProofsPage'
+import LiveBlocksPage from './pages/explorer/LiveBlocksPage'
+import TransactionsPage from './pages/explorer/TransactionsPage'
+import AccountsPage from './pages/explorer/AccountsPage'
+import ContractsPage from './pages/explorer/ContractsPage'
+import ValidatorsPage from './pages/explorer/ValidatorsPage'
+import NetworkMapPage from './pages/explorer/NetworkMapPage'
+import AnalyticsPage from './pages/explorer/AnalyticsPage'
 import NodeSelector from './components/NodeSelector'
 import { getApiBaseUrl, getHealth } from './lib/api'
 import { UIConfig } from './lib/config'
@@ -9,16 +32,65 @@ import { UIConfig } from './lib/config'
 const navigation = [
   {
     title: 'Overview',
+    items: [{ name: 'Node Dashboard', path: '/dashboard', icon: '📊' }],
+  },
+  {
+    title: 'Wallet & Payments',
     items: [
-      { name: 'Node Dashboard', path: '/dashboard', icon: '📊' },
-      { name: 'Wallet', path: '/wallet', icon: '💰' },
+      { name: 'Wallet Control Center', path: '/wallet', icon: '💼' },
+      { name: 'Wallet Playground', path: '/wallet/legacy', icon: '🧪' },
+      { name: 'Payments', path: '/wallet/payments', icon: '💸' },
+      { name: 'Machine Payments', path: '/wallet/m2m', icon: '🤖' },
+    ],
+  },
+  {
+    title: 'Staking & Governance',
+    items: [
+      { name: 'Staking', path: '/staking', icon: '🪙' },
+      { name: 'Validator Ops', path: '/staking/validators', icon: '🛠️' },
+    ],
+  },
+  {
+    title: 'Domains & Interop',
+    items: [
+      { name: 'Domain Manager', path: '/domains', icon: '🌐' },
+      { name: 'Domain Updates', path: '/domains/updates', icon: '📰' },
+      { name: 'Interoperability', path: '/domains/interoperability', icon: '🔗' },
+    ],
+  },
+  {
+    title: 'Storage & Data',
+    items: [
+      { name: 'Storage Control', path: '/storage', icon: '🗄️' },
+      { name: 'File Availability', path: '/storage/availability', icon: '🧾' },
+    ],
+  },
+  {
+    title: 'Neural Network',
+    items: [
+      { name: 'Control Center', path: '/neural', icon: '🧠' },
+      { name: 'Models API', path: '/neural/models', icon: '📚' },
+      { name: 'Datasets', path: '/neural/datasets', icon: '🧬' },
+      { name: 'Inference', path: '/neural/inference', icon: '⚙️' },
+      { name: 'Bids & Auctions', path: '/neural/bids', icon: '🏅' },
+      { name: 'Proofs', path: '/neural/proofs', icon: '✅' },
+    ],
+  },
+  {
+    title: 'Explorer',
+    items: [
+      { name: 'Live Blocks', path: '/explorer/live-blocks', icon: '🧱' },
+      { name: 'Transactions', path: '/explorer/transactions', icon: '💳' },
+      { name: 'Accounts', path: '/explorer/accounts', icon: '👤' },
+      { name: 'Contracts', path: '/explorer/contracts', icon: '📜' },
+      { name: 'Validators', path: '/explorer/validators', icon: '🛡️' },
+      { name: 'Network Map', path: '/explorer/network-map', icon: '🗺️' },
+      { name: 'Analytics', path: '/explorer/analytics', icon: '📈' },
     ],
   },
   {
     title: 'Operations',
-    items: [
-      { name: 'Node Selection', path: '/node-selector', icon: '🛰️' },
-    ],
+    items: [{ name: 'Node Selector', path: '/operations/node-selector', icon: '🛰️' }],
   },
 ] as const
 
@@ -94,6 +166,7 @@ export default function App() {
                   <NavLink
                     key={item.path}
                     to={item.path}
+                    end
                     className={({ isActive }) =>
                       `nav-item flex items-center space-x-3 ${isActive ? 'active' : ''}`
                     }
@@ -114,8 +187,40 @@ export default function App() {
             <Routes>
               <Route path="/" element={<Navigate to="/dashboard" replace />} />
               <Route path="/dashboard" element={<DashboardPage />} />
+
               <Route path="/wallet" element={<WalletOverview />} />
+              <Route path="/wallet/legacy" element={<WalletPage />} />
+              <Route path="/wallet/payments" element={<PaymentsPage />} />
+              <Route path="/wallet/m2m" element={<PaymentsM2M />} />
+
+              <Route path="/staking" element={<StakingPage />} />
+              <Route path="/staking/validators" element={<StakingValidator />} />
+
+              <Route path="/domains" element={<DomainsPage />} />
+              <Route path="/domains/updates" element={<DomainUpdatesPage />} />
+              <Route path="/domains/interoperability" element={<InteroperabilityPage />} />
+
+              <Route path="/storage" element={<StoragePage />} />
+              <Route path="/storage/availability" element={<FileAvailabilityPage />} />
+
+              <Route path="/neural" element={<NeuralModels />} />
+              <Route path="/neural/models" element={<ModelsPage />} />
+              <Route path="/neural/datasets" element={<DatasetsPage />} />
+              <Route path="/neural/inference" element={<InferencePage />} />
+              <Route path="/neural/bids" element={<BidsPage />} />
+              <Route path="/neural/proofs" element={<ProofsPage />} />
+
+              <Route path="/explorer/live-blocks" element={<LiveBlocksPage />} />
+              <Route path="/explorer/transactions" element={<TransactionsPage />} />
+              <Route path="/explorer/accounts" element={<AccountsPage />} />
+              <Route path="/explorer/contracts" element={<ContractsPage />} />
+              <Route path="/explorer/validators" element={<ValidatorsPage />} />
+              <Route path="/explorer/network-map" element={<NetworkMapPage />} />
+              <Route path="/explorer/analytics" element={<AnalyticsPage />} />
+
+              <Route path="/operations/node-selector" element={<NodeSelector />} />
               <Route path="/node-selector" element={<NodeSelector />} />
+
               <Route path="*" element={<Navigate to="/dashboard" replace />} />
             </Routes>
           </div>

--- a/apps/unified-ui/src/lib/walletStore.ts
+++ b/apps/unified-ui/src/lib/walletStore.ts
@@ -1,0 +1,65 @@
+import { create } from 'zustand'
+
+export const WALLET_STORAGE_KEY = 'ippan.wallet.address'
+export const WALLET_ADDRESS_REGEX = /^i[0-9a-fA-F]{64}$/
+
+type WalletState = {
+  address: string
+  setAddress: (address: string) => void
+  clearAddress: () => void
+}
+
+function readStoredAddress(): string {
+  if (typeof window === 'undefined') {
+    return ''
+  }
+
+  try {
+    return window.localStorage.getItem(WALLET_STORAGE_KEY) ?? ''
+  } catch (error) {
+    console.warn('Unable to read wallet address from storage:', error)
+    return ''
+  }
+}
+
+export const useWalletStore = create<WalletState>((set) => ({
+  address: readStoredAddress(),
+  setAddress: (address) => {
+    set({ address })
+
+    if (typeof window !== 'undefined') {
+      try {
+        window.localStorage.setItem(WALLET_STORAGE_KEY, address)
+      } catch (error) {
+        console.warn('Unable to persist wallet address:', error)
+      }
+    }
+  },
+  clearAddress: () => {
+    set({ address: '' })
+
+    if (typeof window !== 'undefined') {
+      try {
+        window.localStorage.removeItem(WALLET_STORAGE_KEY)
+      } catch (error) {
+        console.warn('Unable to clear wallet address:', error)
+      }
+    }
+  },
+}))
+
+if (typeof window !== 'undefined') {
+  window.addEventListener('storage', (event) => {
+    if (event.key === WALLET_STORAGE_KEY) {
+      useWalletStore.setState({ address: event.newValue ?? '' })
+    }
+  })
+}
+
+export function isValidWalletAddress(address: string | null | undefined): boolean {
+  if (!address) {
+    return false
+  }
+
+  return WALLET_ADDRESS_REGEX.test(address)
+}

--- a/apps/unified-ui/src/pages/PaymentsM2M.tsx
+++ b/apps/unified-ui/src/pages/PaymentsM2M.tsx
@@ -1,5 +1,6 @@
 import { useState, useEffect, useMemo } from 'react'
 import { Card, Button, Input, Badge, Switch, Select, SelectTrigger, SelectValue, SelectContent, SelectItem, Sheet, SheetContent, SheetHeader, SheetTitle, SheetFooter, Label, Textarea } from '../components/UI'
+import { isValidWalletAddress, useWalletStore } from '../lib/walletStore'
 
 // =============== Types ===============
 type FeePreview = { fee: number; nonce: number; etaSeconds: number };
@@ -143,15 +144,9 @@ async function apiSaveWebhook(url: string, events: string[]): Promise<{ok:boolea
 }
 
 // =============== Component ===============
-interface PaymentsM2MProps {
-  walletAddress: string | null;
-  walletConnected: boolean;
-}
-
-export default function PaymentsM2M({ walletAddress, walletConnected }: PaymentsM2MProps) {
-  // Use wallet state from props instead of local state
-  const address = walletAddress;
-  const connected = walletConnected;
+export default function PaymentsM2M() {
+  const address = useWalletStore((state) => state.address);
+  const connected = isValidWalletAddress(address);
 
   // Pay form
   const [to, setTo] = useState("");


### PR DESCRIPTION
## Summary
- expand the unified console navigation to include wallet, staking, domain, storage, neural, and explorer workflows
- add routes for all unified UI pages and expose the advanced wallet, payments, and explorer screens at ui.ippan.org
- centralize wallet connection state in a persisted Zustand store so components like payments and M2M share the same address

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d7c7aeba30832b8e7e63f14a64bb85