### PR TITLE
Document unified UI deployment at 188.245.97.41

### DIFF
--- a/deploy/unified-ui-deployment.md
+++ b/deploy/unified-ui-deployment.md
@@ -48,7 +48,7 @@ Below is an example Nginx server block that proxies incoming traffic to the UI c
 ```nginx
 server {
   listen 80;
-  server_name ui.ippan.org 135.181.145.174 188.245.97.41;
+  server_name 188.245.97.41;
 
   location / {
     proxy_pass http://127.0.0.1:3000;
@@ -62,6 +62,10 @@ server {
   location /health { return 200 "ok"; }
 }
 ```
+
+With this configuration the unified UI is served directly from
+`http://188.245.97.41`, replacing the former
+`https://ui.ippan.org/dashboard` address.
 
 For Envoy-based setups, ensure the virtual host configuration includes the incoming domain or use `"*"` to accept all hosts.
 The repository now ships with a ready-to-use configuration at


### PR DESCRIPTION
## Summary
- update the sample Nginx configuration to serve the unified UI from 188.245.97.41
- clarify that the IP address replaces the previous ui.ippan.org/dashboard endpoint

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d81b115f5c832b8928c8b1ed304da4