### PR TITLE
Apply consensus account updates when ingesting P2P blocks

### DIFF
--- a/crates/consensus/src/lib.rs
+++ b/crates/consensus/src/lib.rs
@@ -278,8 +278,32 @@ impl PoAConsensus {
         Ok(())
     }
 
+    /// Apply transactions and block rewards using the consensus configuration
+    pub async fn apply_block_state(
+        &self,
+        transactions: &[Transaction],
+        proposer_id: [u8; 32],
+    ) -> Result<()> {
+        Self::apply_transactions_to_storage(
+            &self.storage,
+            transactions,
+            self.config.block_reward,
+            proposer_id,
+        )
+        .await
+    }
+
     /// Process transactions and update account balances
     async fn process_transactions(
+        storage: &Arc<dyn Storage + Send + Sync>,
+        transactions: &[Transaction],
+        block_reward: u64,
+        proposer_id: [u8; 32],
+    ) -> Result<()> {
+        Self::apply_transactions_to_storage(storage, transactions, block_reward, proposer_id).await
+    }
+
+    async fn apply_transactions_to_storage(
         storage: &Arc<dyn Storage + Send + Sync>,
         transactions: &[Transaction],
         block_reward: u64,


### PR DESCRIPTION
## Summary
- extract the PoA account update logic into a reusable helper and expose it through `ConsensusHandle`
- call the helper from the P2P block handlers so persisted blocks also update account balances and rewards
- add a regression test that verifies sender and receiver balances change after ingesting a funded block message

## Testing
- cargo test -p ippan-rpc

------
https://chatgpt.com/codex/tasks/task_e_68d8dd7b0c94832bbe8e2e72e40da5fe