### PR TITLE
Update Rust toolchain to 1.88 for Docker builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # ---- Build stage ------------------------------------------------------------
-FROM rust:1.80-bullseye AS builder
+FROM rust:1.88-slim AS builder
 
 # Native deps commonly needed by Rust crates (openssl, protobuf, etc.)
 RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,3 @@
+[toolchain]
+channel = "1.88.0"
+components = ["rustfmt", "clippy"]


### PR DESCRIPTION
## Summary
- add a rust-toolchain.toml to pin Rust 1.88.0 with rustfmt and clippy components
- update the Docker builder stage to use the rust:1.88-slim image so Cargo 1.88 is available

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d8f7197ad8832b947457c09b3b1788