### PR TITLE
Fix block constructor usage in RPC tests

### DIFF
--- a/crates/rpc/src/server.rs
+++ b/crates/rpc/src/server.rs
@@ -67,7 +67,7 @@ impl ConsensusHandle {
     pub async fn apply_block_state(&self, block: &Block) -> Result<()> {
         let consensus = self.consensus.lock().await;
         consensus
-            .apply_block_state(&block.transactions, block.header.proposer_id)
+            .apply_block_state(&block.transactions, block.header.creator)
             .await
     }
 }
@@ -903,7 +903,7 @@ mod tests {
             })
             .expect("seed sender");
 
-        let block = Block::new([1u8; 32], vec![tx], 1, proposer_id);
+        let block = Block::with_parent([1u8; 32], vec![tx], 1, proposer_id);
 
         let status = p2p_blocks_handler(State(state.clone()), Json(NetworkMessage::Block(block)))
             .await

--- a/crates/types/src/block.rs
+++ b/crates/types/src/block.rs
@@ -149,6 +149,16 @@ impl Block {
         }
     }
 
+    /// Convenience constructor for creating a block with a single parent.
+    pub fn with_parent(
+        parent_id: BlockId,
+        transactions: Vec<Transaction>,
+        round: RoundId,
+        creator: ValidatorId,
+    ) -> Self {
+        Self::new(vec![parent_id], transactions, round, creator)
+    }
+
     /// Compute the merkle root for an arbitrary slice of 32-byte hashes.
     pub fn compute_merkle_root_from_hashes(items: &[BlockId]) -> [u8; 32] {
         if items.is_empty() {


### PR DESCRIPTION
## Summary
- add a `Block::with_parent` helper for single-parent blocks
- update the RPC server test to use the helper and pass the header creator to consensus state application

## Testing
- cargo check -p ippan-rpc --tests

------
https://chatgpt.com/codex/tasks/task_e_68d8fb4a1680832ba02ef443e95c42ef