### PR TITLE
Fix RPC block handler test setup

### DIFF
--- a/crates/rpc/src/server.rs
+++ b/crates/rpc/src/server.rs
@@ -940,7 +940,7 @@ mod tests {
             })
             .expect("seed sender");
 
-
+        let block = make_block(vec![tx.clone()]);
 
         let status = p2p_blocks_handler(State(state.clone()), Json(NetworkMessage::Block(block)))
             .await


### PR DESCRIPTION
## Summary
- build a block from the seeded transaction in the RPC incoming block test so the handler receives valid data

## Testing
- cargo test

------
https://chatgpt.com/codex/tasks/task_e_68d915b4751c832bb1443e04561bfe67