### PR TITLE
Fix RPC block handler test block creation

### DIFF
--- a/crates/rpc/src/server.rs
+++ b/crates/rpc/src/server.rs
@@ -940,7 +940,7 @@ mod tests {
             })
             .expect("seed sender");
 
-
+        let block = make_block(vec![tx]);
 
         let status = p2p_blocks_handler(State(state.clone()), Json(NetworkMessage::Block(block)))
             .await


### PR DESCRIPTION
## Summary
- create a block in the `incoming_block_updates_accounts` test before calling the handler

## Testing
- cargo test -p ippan-rpc --lib

------
https://chatgpt.com/codex/tasks/task_e_68d91f599e2c832bb674e77e8369c80a