### PR TITLE
Stop binding ippan container to host port 3000

### DIFF
--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -1,5 +1,3 @@
-version: "3.9"
-
 services:
   ippan:
     image: ghcr.io/dmrl789/ippan:latest
@@ -8,7 +6,6 @@ services:
     env_file: /opt/ippan/.env
     ports:
       - "7070:7070"
-      - "3000:3000"
     volumes:
       - /opt/ippan/data:/var/lib/ippan
     command: []


### PR DESCRIPTION
## Summary
- remove the deprecated compose `version` field
- stop publishing the ippan container's port 3000 on the host to avoid conflicts with other services

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68db9d3d11c8832b85b1f7abb14dc717