### PR TITLE
Add round-aware PoA finalization and fast slots

### DIFF
--- a/crates/rpc/src/server.rs
+++ b/crates/rpc/src/server.rs
@@ -349,7 +349,7 @@ async fn consensus_handler(State(state): State<Arc<AppState>>) -> ApiResult<Cons
     };
 
     Ok(Json(ConsensusStats {
-        current_round: consensus_state.current_slot,
+        current_round: consensus_state.current_round,
         validators_count: validators.len(),
         block_height: consensus_state.latest_block_height,
         consensus_status: status.to_string(),

--- a/node/src/main.rs
+++ b/node/src/main.rs
@@ -35,6 +35,7 @@ struct AppConfig {
     slot_duration_ms: u64,
     max_transactions_per_block: usize,
     block_reward: u64,
+    finalization_interval_ms: u64,
 
     // L2 interoperability
     l2_max_commit_size: usize,
@@ -144,7 +145,7 @@ impl AppConfig {
                 .unwrap_or_else(|_| "./data/db".to_string()),
             slot_duration_ms: config
                 .get_string("SLOT_DURATION_MS")
-                .unwrap_or_else(|_| "1000".to_string())
+                .unwrap_or_else(|_| "100".to_string())
                 .parse()?,
             max_transactions_per_block: config
                 .get_string("MAX_TRANSACTIONS_PER_BLOCK")
@@ -153,6 +154,10 @@ impl AppConfig {
             block_reward: config
                 .get_string("BLOCK_REWARD")
                 .unwrap_or_else(|_| "10".to_string())
+                .parse()?,
+            finalization_interval_ms: config
+                .get_string("FINALIZATION_INTERVAL_MS")
+                .unwrap_or_else(|_| "200".to_string())
                 .parse()?,
             l2_max_commit_size: config
                 .get_string("L2_MAX_COMMIT_SIZE")
@@ -283,6 +288,7 @@ async fn main() -> Result<()> {
         }],
         max_transactions_per_block: config.max_transactions_per_block,
         block_reward: config.block_reward,
+        finalization_interval_ms: config.finalization_interval_ms,
     };
 
     let consensus_instance =


### PR DESCRIPTION
## Summary
- gate PoA block production on non-empty mempool entries and spawn async transaction processing so proposal work overlaps
- track finalization rounds with a round frontier to build block DAG parents and finalize batches every 100-250 ms via deterministic ordering
- expose round metrics through the RPC/API and surface new timing configuration defaults for fast slots

## Testing
- cargo test

------
https://chatgpt.com/codex/tasks/task_e_68dbb97f6cfc832baaf690de85942814