### PR TITLE
Add yamllint config and normalize apply-patch workflow

### DIFF
--- a/.github/workflows/apply-patch-from-issue.yml
+++ b/.github/workflows/apply-patch-from-issue.yml
@@ -1,5 +1,4 @@
 name: Apply Patch From Issue
-
 on:
   issues:
     types: [opened, edited, reopened, labeled]

--- a/.yamllint.yml
+++ b/.yamllint.yml
@@ -1,9 +1,26 @@
+# Yamllint config tuned for GitHub Actions workflows
+# Ref: https://github.com/adrienverge/yamllint
 extends: default
 
 rules:
-  document-start: enable
+  document-start:
+    present: false   # GH Actions doesn't require '---' everywhere
   line-length:
     max: 200
-    level: warning
+    allow-non-breakable-words: true
+    allow-non-breakable-inline-mappings: true
   truthy:
-    check-keys: false
+    check-keys: false  # allow keys named 'on', etc.
+  indentation:
+    indent-sequences: consistent
+  comments:
+    min-spaces-from-content: 1
+  empty-lines:
+    max: 2
+  hyphens:
+    max-spaces-after: 1
+
+ignore: |
+  # Ignore vendor/cache dirs if any
+  **/node_modules/**
+  **/.git/**


### PR DESCRIPTION
## Summary
- add a repository yamllint configuration tailored for GitHub Actions workflow files
- normalize the apply-patch-from-issue workflow formatting to align with the linter rules

## Testing
- not run (yamllint not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68dcf58a97b0832bad13d620b8faa27c