### PR TITLE
Fix dev CLI flag configuration for ippan-node

### DIFF
--- a/node/src/main.rs
+++ b/node/src/main.rs
@@ -1,5 +1,5 @@
 use anyhow::Result;
-use clap::{Arg, Command};
+use clap::{Arg, ArgAction, Command};
 use config::Config;
 use ippan_consensus::{PoAConfig, PoAConsensus, Validator};
 use ippan_p2p::{HttpP2PNetwork, P2PConfig};
@@ -239,7 +239,12 @@ async fn main() -> Result<()> {
                 .value_name("DIR")
                 .help("Data directory"),
         )
-        .arg(Arg::new("dev").long("dev").help("Run in development mode"))
+        .arg(
+            Arg::new("dev")
+                .long("dev")
+                .action(ArgAction::SetTrue)
+                .help("Run in development mode"),
+        )
         .get_matches();
 
     // Load configuration


### PR DESCRIPTION
## Summary
- configure the `--dev` flag with `ArgAction::SetTrue` to satisfy clap's requirements and avoid a runtime panic when starting the node
- import `ArgAction` for the updated flag setup

## Testing
- cargo run -p ippan-node
- cargo test


------
https://chatgpt.com/codex/tasks/task_e_68dcf684da1c832bbf5b7261375043d4