### PR TITLE
Bind edge container to localhost port

### DIFF
--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -19,7 +19,7 @@ services:
     depends_on:
       - ippan
     ports:
-      - "80:80"
+      - "127.0.0.1:8080:80"
     volumes:
       - ./nginx.conf:/etc/nginx/conf.d/default.conf:ro
     networks:


### PR DESCRIPTION
## Summary
- bind the ippan-edge service to localhost port 8080 to avoid host port 80 conflicts

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68dcfc9fc3b4832b9e42f66ee9104cc2