### PR TITLE
Fix yamllint failure in docker-build workflow

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -3,7 +3,7 @@ name: Build and Push Docker Image
 
 "on":
   push:
-    branches: [ main ]
+    branches: [main]
     paths: ["**/*.rs", "Cargo.*", "Dockerfile", ".github/workflows/docker-build.yml"]
   workflow_dispatch:
 


### PR DESCRIPTION
## Summary
- adjust the branches list formatting in the docker-build workflow to satisfy yamllint

## Testing
- cargo fmt --all -- --check
- cargo clippy --workspace --all-targets --all-features -- -D warnings
- cargo test --workspace --all-features -- --nocapture
- npm run lint
- npm run build
- yamllint .github/workflows


------
https://chatgpt.com/codex/tasks/task_e_68dcfdd2d5f8832bb3b5ff5493055f87