### PR TITLE
Fix yamllint warnings by removing document starts

### DIFF
--- a/.github/workflows/chatops-apply-patch.yml
+++ b/.github/workflows/chatops-apply-patch.yml
@@ -1,4 +1,3 @@
----
 name: ChatOps - Apply Patch
 
 "on":

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,3 @@
----
 name: CI
 
 on: [push, pull_request]

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -1,4 +1,3 @@
----
 name: Build and Push Docker Image
 
 "on":

--- a/.github/workflows/triage.yml
+++ b/.github/workflows/triage.yml
@@ -1,4 +1,3 @@
----
 name: Auto-label & triage
 "on":
   issues:

--- a/.github/workflows/yamllint.yml
+++ b/.github/workflows/yamllint.yml
@@ -1,4 +1,3 @@
----
 name: Lint YAML (workflows)
 "on":
   pull_request:


### PR DESCRIPTION
## Summary
- remove YAML document start markers from workflow files so they conform to the repository's yamllint configuration

## Testing
- yamllint .github/workflows

------
https://chatgpt.com/codex/tasks/task_e_68dd070f57d8832b9dddcd9291f7a486