### PR TITLE
Prevent workflow fixer from altering shell test brackets

### DIFF
--- a/.github/scripts/fix_workflows.py
+++ b/.github/scripts/fix_workflows.py
@@ -13,6 +13,9 @@ def fix_inline_brackets(txt: str) -> str:
     # Convert inline lists with inner spaces --> no inner spaces (least invasive)
     def repl(m):
         inner = m.group(1)
+        if ',' not in inner:
+            # Likely a shell test (e.g. `[ -f file ]`) or similar construct – do not touch it.
+            return m.group(0)
         compact = re.sub(r'\s*,\s*', ', ', re.sub(r'^\s+|\s+$', '', inner))
         return f'[{compact}]'
     return re.sub(r'\[(.*?)\]', repl, txt)


### PR DESCRIPTION
## Summary
- guard the inline bracket normalization against inputs without commas so shell tests keep their spacing

## Testing
- python3 -m compileall .github/scripts/fix_workflows.py

------
https://chatgpt.com/codex/tasks/task_e_68dd20d3ed78832ba46f929ebe8bbf43