### PR TITLE
Handle deploy script without sudo availability

### DIFF
--- a/.github/workflows/deploy-ui.yml
+++ b/.github/workflows/deploy-ui.yml
@@ -124,6 +124,24 @@ jobs:
           envs: IMAGE_PREFIX,NEXT_PUBLIC_GATEWAY_URL,NEXT_PUBLIC_API_BASE_URL,NEXT_PUBLIC_WS_URL,NEXT_PUBLIC_ENABLE_FULL_UI,TARGET_RPC_URL,TARGET_WS_URL,TARGET_HEALTH_PATH,HEALTH_TIMEOUT_MS,GATEWAY_ALLOWED_ORIGINS,GITHUB_TOKEN,GITHUB_ACTOR
           script: |
             set -euo pipefail
+            if command -v sudo >/dev/null 2>&1; then
+              if sudo -n true 2>/dev/null; then
+                SUDO="sudo"
+              else
+                echo "sudo requires a password; continuing without sudo"
+                SUDO=""
+              fi
+            else
+              SUDO=""
+            fi
+
+            run_root() {
+              if [ -n "$SUDO" ]; then
+                sudo "$@"
+              else
+                "$@"
+              fi
+            }
             IMAGE_PREFIX="${IMAGE_PREFIX,,}"
             : "${NEXT_PUBLIC_GATEWAY_URL:=https://ui.ippan.org/api}"
             : "${NEXT_PUBLIC_API_BASE_URL:=${NEXT_PUBLIC_GATEWAY_URL}}"
@@ -136,11 +154,49 @@ jobs:
             : "${GATEWAY_ALLOWED_ORIGINS:=https://ui.ippan.org}"
 
             APP_DIR=/opt/ippan/ui
-            sudo mkdir -p "$APP_DIR"
-            sudo chown -R "$USER":"$USER" "$APP_DIR" || true
+            run_root mkdir -p "$APP_DIR"
+            run_root chown -R "$USER":"$USER" "$APP_DIR" || true
             cd "$APP_DIR"
 
-            sudo tee docker-compose.yml >/dev/null <<'YML'
+            if [ -n "$SUDO" ]; then
+              sudo tee docker-compose.yml >/dev/null <<'YML'
+            version: "3.8"
+            services:
+              ui:
+                image: ${IMAGE_PREFIX}/ui:latest
+                env_file:
+                  - .env
+                restart: unless-stopped
+                networks:
+                  - web
+                ports:
+                  - "127.0.0.1:3000:3000"
+              gateway:
+                image: ${IMAGE_PREFIX}/gateway:latest
+                env_file:
+                  - .env
+                restart: unless-stopped
+                networks:
+                  - web
+                depends_on:
+                  - node
+                ports:
+                  - "127.0.0.1:8080:8080"
+              node:
+                image: ${IMAGE_PREFIX}/node:latest
+                env_file:
+                  - .env
+                restart: unless-stopped
+                networks:
+                  - web
+                ports:
+                  - "127.0.0.1:9090:9090"
+            networks:
+              web:
+                driver: bridge
+YML
+            else
+              cat <<'YML' > docker-compose.yml
             version: "3.8"
             services:
               ui:
@@ -177,7 +233,22 @@ jobs:
                 driver: bridge
             YML
 
-            sudo tee .env >/dev/null <<'ENV'
+            if [ -n "$SUDO" ]; then
+              sudo tee .env >/dev/null <<'ENV'
+            NODE_ENV=production
+            NEXT_PUBLIC_GATEWAY_URL=${NEXT_PUBLIC_GATEWAY_URL}
+            NEXT_PUBLIC_API_BASE_URL=${NEXT_PUBLIC_API_BASE_URL}
+            NEXT_PUBLIC_WS_URL=${NEXT_PUBLIC_WS_URL}
+            NEXT_PUBLIC_ENABLE_FULL_UI=${NEXT_PUBLIC_ENABLE_FULL_UI}
+            ENABLE_FULL_UI=${NEXT_PUBLIC_ENABLE_FULL_UI}
+            TARGET_RPC_URL=${TARGET_RPC_URL}
+            TARGET_WS_URL=${TARGET_WS_URL}
+            TARGET_HEALTH_PATH=${TARGET_HEALTH_PATH}
+            HEALTH_TIMEOUT_MS=${HEALTH_TIMEOUT_MS}
+            ALLOWED_ORIGINS=${GATEWAY_ALLOWED_ORIGINS}
+ENV
+            else
+              cat <<'ENV' > .env
             NODE_ENV=production
             NEXT_PUBLIC_GATEWAY_URL=${NEXT_PUBLIC_GATEWAY_URL}
             NEXT_PUBLIC_API_BASE_URL=${NEXT_PUBLIC_API_BASE_URL}
@@ -191,9 +262,52 @@ jobs:
             ALLOWED_ORIGINS=${GATEWAY_ALLOWED_ORIGINS}
             ENV
 
-            sudo mkdir -p /etc/nginx/sites-available /etc/nginx/sites-enabled
+            fi
 
-            sudo tee /etc/nginx/sites-available/ui.ippan.org >/dev/null <<'NGINX'
+            run_root mkdir -p /etc/nginx/sites-available /etc/nginx/sites-enabled
+
+            if [ -n "$SUDO" ]; then
+              sudo tee /etc/nginx/sites-available/ui.ippan.org >/dev/null <<'NGINX'
+            server {
+              listen 80;
+              server_name ui.ippan.org;
+              return 301 https://$host$request_uri;
+            }
+
+            server {
+              listen 443 ssl http2;
+              server_name ui.ippan.org;
+
+              ssl_certificate     /etc/letsencrypt/live/ui.ippan.org/fullchain.pem;
+              ssl_certificate_key /etc/letsencrypt/live/ui.ippan.org/privkey.pem;
+
+              location / {
+                proxy_pass http://127.0.0.1:3000;
+                proxy_set_header Host $host;
+                proxy_set_header X-Forwarded-For $remote_addr;
+                proxy_set_header X-Forwarded-Proto https;
+                proxy_read_timeout 300;
+              }
+
+              location /api/ {
+                proxy_pass http://127.0.0.1:8080/;
+                proxy_set_header Host $host;
+                proxy_set_header X-Forwarded-For $remote_addr;
+                proxy_set_header X-Forwarded-Proto https;
+                proxy_read_timeout 300;
+              }
+
+              location /ws/ {
+                proxy_pass http://127.0.0.1:8080/ws/;
+                proxy_http_version 1.1;
+                proxy_set_header Upgrade $http_upgrade;
+                proxy_set_header Connection "upgrade";
+                proxy_set_header Host $host;
+              }
+            }
+NGINX
+            else
+              cat <<'NGINX' > /etc/nginx/sites-available/ui.ippan.org
             server {
               listen 80;
               server_name ui.ippan.org;
@@ -233,7 +347,9 @@ jobs:
             }
             NGINX
 
-            sudo ln -sf /etc/nginx/sites-available/ui.ippan.org /etc/nginx/sites-enabled/ui.ippan.org
+            fi
+
+            run_root ln -sf /etc/nginx/sites-available/ui.ippan.org /etc/nginx/sites-enabled/ui.ippan.org
 
             if docker compose version >/dev/null 2>&1; then
               DC="docker compose"
@@ -241,9 +357,9 @@ jobs:
               DC="docker-compose"
             else
               echo "Installing docker-compose v2..."
-              sudo curl -fsSL "https://github.com/docker/compose/releases/download/v2.27.0/docker-compose-$(uname -s)-$(uname -m)" \
+              run_root curl -fsSL "https://github.com/docker/compose/releases/download/v2.27.0/docker-compose-$(uname -s)-$(uname -m)" \
                 -o /usr/local/bin/docker-compose
-              sudo chmod +x /usr/local/bin/docker-compose
+              run_root chmod +x /usr/local/bin/docker-compose
               DC="docker-compose"
             fi
 
@@ -254,5 +370,8 @@ jobs:
             $DC up -d
             docker system prune -f
 
-            sudo nginx -t
-            sudo systemctl reload nginx
+            run_root nginx -t
+            if ! run_root systemctl reload nginx; then
+              echo "systemctl reload failed; attempting nginx -s reload"
+              run_root nginx -s reload
+            fi


### PR DESCRIPTION
## Summary
- detect when `sudo` is unavailable or requires a password and fall back to running privileged commands directly
- reuse a helper to execute privileged operations and write deployment files whether or not `sudo` works
- add a fallback reload path for nginx when `systemctl` is not available on the target host

## Testing
- not run (workflow change)


------
https://chatgpt.com/codex/tasks/task_e_68dd246a05e0832b9469bd7cb77ad2df