### PR TITLE
Add Codex IPPAN node testing workflow

### DIFF
--- a/.github/workflows/node-tests.yml
+++ b/.github/workflows/node-tests.yml
@@ -1,0 +1,287 @@
+name: IPPAN Node Tests (Codex)
+
+on:
+  workflow_dispatch:
+    inputs:
+      rpc_port:
+        description: "RPC/Edge HTTP port on the server (loopback)."
+        default: "8080"
+        required: true
+      ui_port:
+        description: "UI port (for context only)."
+        default: "3000"
+        required: true
+      tx_endpoint:
+        description: "Transaction POST endpoint path"
+        default: "/tx"
+        required: true
+      accounts_endpoint:
+        description: "Accounts GET endpoint path"
+        default: "/accounts"
+        required: true
+      health_endpoint:
+        description: "Health endpoint path"
+        default: "/health"
+        required: true
+      peers_endpoint:
+        description: "Peers endpoint path"
+        default: "/p2p/peers"
+        required: true
+      block_endpoint:
+        description: "Block endpoint path"
+        default: "/block"
+        required: true
+      test_duration_sec:
+        description: "How long to monitor (seconds)"
+        default: "120"
+        required: true
+      simulate_two_nodes:
+        description: "Run cross-node checks using SECOND_* secrets (true/false)"
+        default: "false"
+        required: true
+
+jobs:
+  test-node:
+    runs-on: ubuntu-latest
+    concurrency:
+      group: ${{ github.workflow }}-${{ github.ref }}-tests
+      cancel-in-progress: true
+
+    steps:
+      - name: Show plan
+        run: |
+          echo "Target host: ${{ secrets.DEPLOY_HOST }}"
+          echo "RPC port: ${{ github.event.inputs.rpc_port }}"
+          echo "Simulate two nodes: ${{ github.event.inputs.simulate_two_nodes }}"
+
+      - name: Push scripts & run tests on PRIMARY
+        uses: appleboy/ssh-action@v1.2.0
+        with:
+          host: ${{ secrets.DEPLOY_HOST }}
+          username: ${{ secrets.DEPLOY_USER }}
+          key: ${{ secrets.DEPLOY_SSH_KEY }}
+          command_timeout: 40m
+          script: |
+            set -Eeuo pipefail
+
+            RPC_PORT="${{ github.event.inputs.rpc_port }}"
+            UI_PORT="${{ github.event.inputs.ui_port }}"
+            EP_TX="${{ github.event.inputs.tx_endpoint }}"
+            EP_ACCOUNTS="${{ github.event.inputs.accounts_endpoint }}"
+            EP_HEALTH="${{ github.event.inputs.health_endpoint }}"
+            EP_PEERS="${{ github.event.inputs.peers_endpoint }}"
+            EP_BLOCK="${{ github.event.inputs.block_endpoint }}"
+            DURATION="${{ github.event.inputs.test_duration_sec }}"
+
+            WORKDIR="$HOME/ippan-tests"
+            mkdir -p "$WORKDIR"
+            cd "$WORKDIR"
+
+            # ---------------- monitor-ippan.sh ----------------
+            cat > monitor-ippan.sh << 'MON'
+            #!/usr/bin/env bash
+            set -Eeuo pipefail
+            RPC_PORT="${RPC_PORT:-8080}"
+            EP_HEALTH="${EP_HEALTH:-/health}"
+            EP_PEERS="${EP_PEERS:-/p2p/peers}"
+            EP_BLOCK="${EP_BLOCK:-/block}"
+
+            base="http://127.0.0.1:${RPC_PORT}"
+
+            ts() { date -Iseconds; }
+
+            echo "[info] Monitoring ${base} for ${DURATION:-120}s"
+            start=$(date +%s)
+            last_height=-1
+            while true; do
+              now=$(date +%s)
+              [[ $((now-start)) -ge ${DURATION:-120} ]] && break
+
+              h=$(curl -fsS "${base}${EP_HEALTH}" || echo "ERR")
+              p=$(curl -fsS "${base}${EP_PEERS}" || echo "ERR")
+              b=$(curl -fsS "${base}${EP_BLOCK}" || echo "ERR")
+
+              height=$(echo "$b" | jq -r '.height // .block.height // .height // -1' 2>/dev/null || echo -1)
+              peers=$(echo "$p" | jq -r '(.peers | length) // .len // length // 0' 2>/dev/null || echo 0)
+
+              echo "$(ts)  health=${h}  peers=${peers}  height=${height}"
+
+              # basic warnings
+              if [[ "$h" == "ERR" || "$p" == "ERR" || "$b" == "ERR" ]]; then
+                echo "::warning::RPC returned an error (health/peers/block)."
+              fi
+              if [[ "$last_height" -ge 0 && "$height" -ge 0 && "$height" -le "$last_height" ]]; then
+                echo "::warning::Block height did not advance."
+              fi
+
+              last_height="$height"
+              sleep 2
+            done
+            MON
+            chmod +x monitor-ippan.sh
+
+            # ---------------- multi-node-tests.sh ----------------
+            cat > multi-node-tests.sh << 'TESTS'
+            #!/usr/bin/env bash
+            set -Eeuo pipefail
+            # Primary node (this host)
+            RPC_PORT="${RPC_PORT:-8080}"
+            EP_TX="${EP_TX:-/tx}"
+            EP_ACCOUNTS="${EP_ACCOUNTS:-/accounts}"
+            EP_BLOCK="${EP_BLOCK:-/block}"
+
+            PRI="http://127.0.0.1:${RPC_PORT}"
+
+            # If SECOND_RPC is provided, we run cross-node checks
+            SECOND_RPC="${SECOND_RPC:-}"
+
+            # 1) Transaction propagation
+            echo "[1] Transaction propagation"
+            # Minimal sample tx payload (adjust to your API)
+            TX_PAYLOAD='{"from":"demo_sender","to":"demo_receiver","amount":1,"memo":"codex-test"}'
+            curl -fsS -X POST -H "content-type: application/json" \
+              --data "$TX_PAYLOAD" \
+              "${PRI}${EP_TX}" | tee tx_resp.json
+
+            sleep 3
+
+            echo "[1.1] Check accounts on primary"
+            curl -fsS "${PRI}${EP_ACCOUNTS}" | jq -r '.' | head -n 50 || true
+
+            if [[ -n "$SECOND_RPC" ]]; then
+              echo "[1.2] Check accounts on secondary"
+              curl -fsS "${SECOND_RPC}${EP_ACCOUNTS}" | jq -r '.' | head -n 50 || true
+            fi
+
+            # 2) Block production advancing
+            echo "[2] Block production advancing"
+            H1=$(curl -fsS "${PRI}${EP_BLOCK}" | jq -r '.height // .block.height // -1' || echo -1)
+            sleep 5
+            H2=$(curl -fsS "${PRI}${EP_BLOCK}" | jq -r '.height // .block.height // -1' || echo -1)
+            echo "Primary heights: $H1 -> $H2"
+            if [[ "$H2" -lt "$H1" || "$H2" -eq -1 ]]; then
+              echo "::error::Primary block height did not advance"; exit 1
+            fi
+
+            if [[ -n "$SECOND_RPC" ]]; then
+              HS1=$(curl -fsS "${SECOND_RPC}${EP_BLOCK}" | jq -r '.height // .block.height // -1' || echo -1)
+              sleep 5
+              HS2=$(curl -fsS "${SECOND_RPC}${EP_BLOCK}" | jq -r '.height // .block.height // -1' || echo -1)
+              echo "Secondary heights: $HS1 -> $HS2"
+              if [[ "$HS2" -lt "$HS1" || "$HS2" -eq -1 ]]; then
+                echo "::error::Secondary block height did not advance"; exit 1
+              fi
+            fi
+
+            # 3) Network resilience (soft check, only if systemd service exists)
+            echo "[3] Network resilience"
+            if systemctl list-units --type=service --no-legend | grep -q 'ippan-node'; then
+              echo "[3.1] Stop ippan-node"
+              sudo systemctl stop ippan-node
+              sleep 5
+              echo "[3.2] Other peers should remain OK (manual/monitor check)"
+              echo "[3.3] Restart ippan-node"
+              sudo systemctl start ippan-node
+              sleep 5
+              sudo systemctl is-active ippan-node
+            else
+              echo "::notice::No systemd unit 'ippan-node' on this host; skipping stop/start test."
+            fi
+
+            echo "[OK] Tests complete."
+            TESTS
+            chmod +x multi-node-tests.sh
+
+            # Start a short journal tail in background (non-fatal if unit missing)
+            (timeout ${DURATION}s bash -c 'command -v journalctl >/dev/null && journalctl -u ippan-node -f || sleep ${DURATION}' || true) &
+            JPID=$!
+
+            # Run monitoring loop for DURATION seconds
+            DURATION="${DURATION}" RPC_PORT="${RPC_PORT}" EP_HEALTH="${EP_HEALTH}" EP_PEERS="${EP_PEERS}" EP_BLOCK="${EP_BLOCK}" ./monitor-ippan.sh
+
+            # For secondary node tests (optional), we’ll construct SECOND_RPC after we run there.
+            # On the primary host run multi-node tests with SECOND_RPC unset; the matrix step below
+            # will run the same tests on the secondary and pass PRIMARY as SECOND_RPC.
+
+            EP_TX="${EP_TX}" EP_ACCOUNTS="${EP_ACCOUNTS}" EP_BLOCK="${EP_BLOCK}" ./multi-node-tests.sh || (kill "$JPID" || true; exit 1)
+
+            kill "$JPID" || true
+            echo "[done] Primary node tests finished."
+
+      - name: Optional — run cross-node checks from SECONDARY
+        if: ${{ github.event.inputs.simulate_two_nodes == 'true' }}
+        uses: appleboy/ssh-action@v1.2.0
+        with:
+          host: ${{ secrets.SECOND_HOST }}
+          username: ${{ secrets.SECOND_USER }}
+          key: ${{ secrets.SECOND_SSH_KEY }}
+          command_timeout: 40m
+          script: |
+            set -Eeuo pipefail
+            RPC_PORT="${{ github.event.inputs.rpc_port }}"
+            EP_TX="${{ github.event.inputs.tx_endpoint }}"
+            EP_ACCOUNTS="${{ github.event.inputs.accounts_endpoint }}"
+            EP_HEALTH="${{ github.event.inputs.health_endpoint }}"
+            EP_PEERS="${{ github.event.inputs.peers_endpoint }}"
+            EP_BLOCK="${{ github.event.inputs.block_endpoint }}"
+            DURATION="${{ github.event.inputs.test_duration_sec }}"
+
+            WORKDIR="$HOME/ippan-tests"
+            mkdir -p "$WORKDIR"; cd "$WORKDIR"
+
+            # fetch scripts from PRIMARY via scp if available; else re-create quickly
+            # (for simplicity re-create inline)
+
+            cat > monitor-ippan.sh << 'MON'
+            #!/usr/bin/env bash
+            set -Eeuo pipefail
+            RPC_PORT="${RPC_PORT:-8080}"
+            EP_HEALTH="${EP_HEALTH:-/health}"
+            EP_PEERS="${EP_PEERS:-/p2p/peers}"
+            EP_BLOCK="${EP_BLOCK:-/block}"
+            base="http://127.0.0.1:${RPC_PORT}"
+            ts() { date -Iseconds; }
+            start=$(date +%s)
+            echo "[info] Monitoring ${base} for ${DURATION:-120}s"
+            while [[ $(( $(date +%s) - start )) -lt ${DURATION:-120} ]]; do
+              h=$(curl -fsS "${base}${EP_HEALTH}" || echo ERR)
+              p=$(curl -fsS "${base}${EP_PEERS}" || echo ERR)
+              b=$(curl -fsS "${base}${EP_BLOCK}" || echo ERR)
+              height=$(echo "$b" | jq -r '.height // .block.height // -1' 2>/dev/null || echo -1)
+              peers=$(echo "$p" | jq -r '(.peers | length) // .len // length // 0' 2>/dev/null || echo 0)
+              echo "$(ts)  health=${h}  peers=${peers}  height=${height}"
+              sleep 2
+            done
+            MON
+            chmod +x monitor-ippan.sh
+
+            cat > multi-node-tests.sh << 'TESTS'
+            #!/usr/bin/env bash
+            set -Eeuo pipefail
+            RPC_PORT="${RPC_PORT:-8080}"
+            EP_TX="${EP_TX:-/tx}"
+            EP_ACCOUNTS="${EP_ACCOUNTS:-/accounts}"
+            EP_BLOCK="${EP_BLOCK:-/block}"
+            PRI="http://127.0.0.1:${RPC_PORT}"
+            SECOND_RPC="${SECOND_RPC:-}"
+
+            # Only run cross-node parts here, treating PRIMARY as SECOND_RPC
+            echo "[2-node] Check height advances on this node and compare to SECOND_RPC"
+            H1=$(curl -fsS "${PRI}${EP_BLOCK}" | jq -r '.height // .block.height // -1' || echo -1)
+            HS1=$(curl -fsS "${SECOND_RPC}${EP_BLOCK}" | jq -r '.height // .block.height // -1' || echo -1)
+            sleep 5
+            H2=$(curl -fsS "${PRI}${EP_BLOCK}" | jq -r '.height // .block.height // -1' || echo -1)
+            HS2=$(curl -fsS "${SECOND_RPC}${EP_BLOCK}" | jq -r '.height // .block.height // -1' || echo -1)
+            echo "This host: $H1 -> $H2 ; Other: $HS1 -> $HS2"
+            TESTS
+            chmod +x multi-node-tests.sh
+
+            (timeout ${DURATION}s bash -c 'command -v journalctl >/dev/null && journalctl -u ippan-node -f || sleep ${DURATION}' || true) &
+            JPID=$!
+
+            DURATION="${DURATION}" RPC_PORT="${RPC_PORT}" EP_HEALTH="${EP_HEALTH}" EP_PEERS="${EP_PEERS}" EP_BLOCK="${EP_BLOCK}" ./monitor-ippan.sh
+            SECOND_RPC="http://${{ secrets.DEPLOY_HOST }}:${{ github.event.inputs.rpc_port }}" \
+            EP_TX="${EP_TX}" EP_ACCOUNTS="${EP_ACCOUNTS}" EP_BLOCK="${EP_BLOCK}" ./multi-node-tests.sh || (kill "$JPID" || true; exit 1)
+
+            kill "$JPID" || true
+            echo "[done] Secondary cross-node checks finished."


### PR DESCRIPTION
## Summary
- add a workflow to run Codex IPPAN node monitoring and functional checks over SSH
- include monitoring and multi-node test scripts with optional secondary host support

## Testing
- not run (workflow change only)


------
https://chatgpt.com/codex/tasks/task_e_68dd5bdf4df8832bbf2a489ccd2d4719