### PR TITLE
Fix clippy explicit auto deref warning in RPC server

### DIFF
--- a/crates/rpc/src/server.rs
+++ b/crates/rpc/src/server.rs
@@ -683,7 +683,7 @@ async fn p2p_peers_handler(State(state): State<Arc<AppState>>) -> ApiResult<P2PP
     let peers = state
         .p2p_network
         .as_ref()
-        .map_or_else(Vec::new, |network| HttpP2PNetwork::get_peers(&**network));
+        .map_or_else(Vec::new, |network| network.get_peers());
 
     state.peer_count.store(peers.len(), Ordering::Relaxed);
 


### PR DESCRIPTION
## Summary
- avoid explicitly dereferencing the optional RPC network when gathering peer addresses so clippy passes

## Testing
- cargo clippy --all-targets --all-features -- -D warnings
- cargo test -p ippan-rpc

------
https://chatgpt.com/codex/tasks/task_e_68de346a4f54832bb3480bcc0cdd20c6