### PR TITLE
Fix RPC server lint regression

### DIFF
--- a/crates/rpc/src/server.rs
+++ b/crates/rpc/src/server.rs
@@ -5,7 +5,6 @@ use axum::routing::{get, get_service, post};
 use axum::{Json, Router};
 use serde::{Deserialize, Serialize};
 use std::collections::{HashMap, HashSet};
-use std::convert::TryFrom;
 use std::net::SocketAddr;
 use std::path::PathBuf;
 use std::sync::atomic::{AtomicUsize, Ordering};


### PR DESCRIPTION
## Summary
- update the rpc server header to preserve new configuration fields
- drop the unused `TryFrom` import noted by clippy

## Testing
- cargo fmt --all
- cargo clippy --workspace --all-targets --all-features -- -D warnings
- cargo build --workspace

------
https://chatgpt.com/codex/tasks/task_e_68de73c78f64832bb0ad7a3102a7274c