### PR TITLE
Define CI workflow toolchain input

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,7 @@ jobs:
     env:
       RUST_BACKTRACE: 1
       CARGO_TERM_COLOR: always
+      RUST_TOOLCHAIN: 1.88.0
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -21,6 +22,7 @@ jobs:
       - name: Install toolchain
         uses: dtolnay/rust-toolchain@stable
         with:
+          toolchain: ${{ env.RUST_TOOLCHAIN }}
           components: clippy,rustfmt
 
       - name: Cache cargo dependencies


### PR DESCRIPTION
## Summary
- set a shared `RUST_TOOLCHAIN` environment variable for the CI job so every step knows which Rust channel to use
- configure the rust-toolchain setup action to consume that variable, guaranteeing the required `toolchain` input is always populated

## Testing
- not run (workflow-only change)

------
https://chatgpt.com/codex/tasks/task_e_68de6ef7d4d4832b88ae62aea5c914ac