### PR TITLE
Fix RPC server state handling

### DIFF
--- a/node/src/main.rs
+++ b/node/src/main.rs
@@ -366,6 +366,7 @@ async fn main() -> Result<()> {
         l2_config,
         mempool: mempool.clone(),
         unified_ui_dist: config.unified_ui_dist_dir.clone(),
+        req_count: Arc::new(AtomicUsize::new(0)),
     };
 
     let rpc_host = &config.rpc_host;


### PR DESCRIPTION
## Summary
- refactor the RPC server state to use shared Arcs and expose a start_server helper
- make health, state, and broadcast endpoints resilient to missing subsystems and serializable
- update the node to populate the new RPC state fields

## Testing
- cargo fmt
- cargo check -p ippan-rpc
- cargo check -p ippan-node

------
https://chatgpt.com/codex/tasks/task_e_68de7df8ba6c832ba3259aefc130da80