### PR TITLE
Fix env file templating in deploy workflow

### DIFF
--- a/.github/workflows/deploy-ui.yml
+++ b/.github/workflows/deploy-ui.yml
@@ -219,7 +219,7 @@ jobs:
                 driver: bridge
             YML
 
-            cat <<'ENV' > .env
+            cat <<ENV > .env
             NODE_ENV=production
             NEXT_PUBLIC_GATEWAY_URL=${NEXT_PUBLIC_GATEWAY_URL}
             NEXT_PUBLIC_API_BASE_URL=${NEXT_PUBLIC_API_BASE_URL}


### PR DESCRIPTION
## Summary
- allow the deploy workflow to expand environment variables when writing the runtime .env file so the deployed services receive the configured secrets

## Testing
- not run (workflow change)


------
https://chatgpt.com/codex/tasks/task_e_68de7fed321c832b807593c83a6d305e