### PR TITLE
Ensure port 3000 is free before building UI images

### DIFF
--- a/.github/workflows/deploy-ui.yml
+++ b/.github/workflows/deploy-ui.yml
@@ -50,6 +50,12 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
+      - name: Ensure port 3000 is free
+        run: |
+          if lsof -i:3000; then
+            kill -9 $(lsof -ti:3000)
+          fi
+
       - name: Build and push container images
         env:
           IMAGE_PREFIX: ${{ env.IMAGE_PREFIX }}


### PR DESCRIPTION
## Summary
- add a workflow step that frees port 3000 prior to building and deploying containers

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68de81863390832b88e48acc88eee465