### PR TITLE
Ensure deploy workflow removes stale UI container before redeploy

### DIFF
--- a/.github/workflows/deploy-ui.yml
+++ b/.github/workflows/deploy-ui.yml
@@ -318,7 +318,16 @@ jobs:
             else
               echo "fuser not available; skipping port 3000 cleanup"
             fi
-            docker rm -f ippan-ui-ui-1 2>/dev/null || true
+            remove_container() {
+              local name="$1"
+              if [ -n "$SUDO" ]; then
+                run_root docker rm -f "$name" 2>/dev/null || true
+              else
+                docker rm -f "$name" 2>/dev/null || true
+              fi
+            }
+
+            remove_container "ippan-ui-ui-1"
             $DC pull
             $DC up -d
             docker system prune -f


### PR DESCRIPTION
## Summary
- ensure the deploy script removes any existing ippan-ui-ui-1 container before running docker compose
- run the removal command with sudo when required to avoid permission issues

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68de87afab90832b97be8d68a17eb2fb