### PR TITLE
Make server UI port configurable

### DIFF
--- a/deploy/server/docker-compose.yml
+++ b/deploy/server/docker-compose.yml
@@ -5,7 +5,7 @@ services:
     restart: unless-stopped
     networks: [web]
     ports:
-      - "127.0.0.1:3000:3000"
+      - "127.0.0.1:${UI_HOST_PORT:-3000}:3000"
   gateway:
     image: ghcr.io/OWNER/REPO/gateway:latest
     env_file: .env


### PR DESCRIPTION
## Summary
- allow the server deployment compose file to override the UI host port via the `UI_HOST_PORT` environment variable to avoid local port conflicts

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68de9817e054832bbd1baf0accef889c