### PR TITLE
Add RPC time endpoint with HashTimer metadata

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1327,6 +1327,7 @@ dependencies = [
  "serde_json",
  "tempfile",
  "thiserror 1.0.69",
+ "time",
  "tokio",
  "tower 0.4.13",
  "tower-http",

--- a/crates/rpc/Cargo.toml
+++ b/crates/rpc/Cargo.toml
@@ -22,6 +22,7 @@ tracing = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 hex = { workspace = true }
+time = { workspace = true }
 axum = { workspace = true }
 tower = { workspace = true }
 tower-http = { workspace = true }

--- a/crates/rpc/src/server.rs
+++ b/crates/rpc/src/server.rs
@@ -19,7 +19,10 @@ use hex::encode;
 use ippan_consensus::{ConsensusState, PoAConsensus, Validator};
 use ippan_p2p::HttpP2PNetwork;
 use ippan_storage::Storage;
-use ippan_types::{ippan_time_ingest_sample, Block, Transaction};
+use ippan_types::{
+    ippan_time_ingest_sample, random_nonce, Block, HashTimer, IppanTimeMicros, Transaction,
+};
+use time::{format_description::well_known::Rfc3339, OffsetDateTime};
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct L2Config {
@@ -129,6 +132,25 @@ struct OkResponse {
     ok: bool,
 }
 
+/// Response payload for the `/time` endpoint.
+#[derive(Debug, Serialize)]
+struct TimeResponse {
+    /// Current IPPAN Time in microseconds.
+    ippan_time_microseconds: u64,
+    /// 14-hex prefix extracted from the HashTimer time component.
+    time_prefix_hex: String,
+    /// Full 64-character HashTimer representing this sample.
+    hashtimer: String,
+    /// Wall-clock observation timestamp in RFC3339 format.
+    observed_at: String,
+    /// Milliseconds since the node started.
+    uptime_ms: u128,
+    /// Node identifier reporting the time sample.
+    node_id: String,
+    /// Monotonic request counter for observability.
+    request_count: usize,
+}
+
 /// Submit-transaction DTO.
 #[derive(Debug, Deserialize, Serialize)]
 struct SubmitTx {
@@ -163,6 +185,7 @@ async fn run_rpc_server(app_state: AppState, bind_addr: SocketAddr) -> Result<()
     let mut router = Router::new()
         // health & basic info
         .route("/health", get(health))
+        .route("/time", get(get_time))
         .route("/state", get(get_state))
         .route("/validators", get(get_validators))
         .route("/mempool", get(get_mempool))
@@ -211,6 +234,42 @@ async fn health(State(app): State<AppState>) -> (StatusCode, Json<Health>) {
             req_count: count,
             peer_count,
             node_id: app.node_id.clone(),
+        }),
+    )
+}
+
+async fn get_time(State(app): State<AppState>) -> (StatusCode, Json<TimeResponse>) {
+    let request_count = app.req_count.fetch_add(1, Ordering::Relaxed) + 1;
+    let uptime_ms = app.start_time.elapsed().as_millis();
+
+    let now = IppanTimeMicros::now();
+    let nonce = random_nonce();
+    let hashtimer = HashTimer::derive(
+        "rpc_time",
+        now,
+        b"rpc_time",
+        &now.0.to_be_bytes(),
+        &nonce,
+        app.node_id.as_bytes(),
+    );
+    let hashtimer_hex = hashtimer.to_hex();
+    let time_prefix_hex = hashtimer_hex[..14].to_string();
+
+    let observed = OffsetDateTime::now_utc();
+    let observed_at = observed
+        .format(&Rfc3339)
+        .unwrap_or_else(|_| observed.unix_timestamp().to_string());
+
+    (
+        StatusCode::OK,
+        Json(TimeResponse {
+            ippan_time_microseconds: now.0,
+            time_prefix_hex,
+            hashtimer: hashtimer_hex,
+            observed_at,
+            uptime_ms,
+            node_id: app.node_id.clone(),
+            request_count,
         }),
     )
 }
@@ -350,4 +409,49 @@ async fn broadcast(
     }
 
     Ok(Json(OkResponse { ok: true }))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use axum::extract::State;
+    use ippan_storage::SledStorage;
+    use std::sync::Arc;
+    use tempfile::tempdir;
+
+    #[tokio::test]
+    async fn time_endpoint_returns_hashtimer_and_counts_requests() {
+        let temp_dir = tempdir().expect("tempdir");
+        let storage = SledStorage::new(temp_dir.path()).expect("storage");
+        storage.initialize().expect("init storage");
+        let storage: Arc<dyn Storage + Send + Sync> = Arc::new(storage);
+
+        let app_state = AppState {
+            storage,
+            start_time: Instant::now(),
+            peer_count: Arc::new(AtomicUsize::new(0)),
+            p2p_network: None,
+            tx_sender: None,
+            node_id: "test-node".to_string(),
+            consensus: None,
+            l2_config: L2Config::default(),
+            mempool: Arc::new(parking_lot::RwLock::new(Vec::new())),
+            unified_ui_dist: None,
+            req_count: Arc::new(AtomicUsize::new(0)),
+        };
+
+        let (status_first, Json(first)) = get_time(State(app_state.clone())).await;
+        assert_eq!(status_first, StatusCode::OK);
+        assert_eq!(first.request_count, 1);
+        assert_eq!(first.node_id, "test-node");
+        assert!(first.ippan_time_microseconds > 0);
+        assert_eq!(first.hashtimer.len(), 64);
+        assert_eq!(first.time_prefix_hex.len(), 14);
+        assert!(first.hashtimer.starts_with(&first.time_prefix_hex));
+
+        let (status_second, Json(second)) = get_time(State(app_state)).await;
+        assert_eq!(status_second, StatusCode::OK);
+        assert_eq!(second.request_count, 2);
+        assert_eq!(second.hashtimer.len(), 64);
+    }
 }


### PR DESCRIPTION
## Summary
- add a dedicated `/time` RPC endpoint that returns the current IPPAN time together with fresh HashTimer metadata and uptime details
- expose the endpoint through the Axum router and cover it with an integration-style unit test
- depend on the shared `time` crate to produce RFC3339 timestamps for responses

## Testing
- cargo test --workspace
- cargo run --bin ippan-node


------
https://chatgpt.com/codex/tasks/task_e_68df9cbf02a8832b94bf2bd1b3cfb242