### PR TITLE
Make gateway host port configurable in deployment workflows

### DIFF
--- a/.github/workflows/deploy-ui.yml
+++ b/.github/workflows/deploy-ui.yml
@@ -21,6 +21,8 @@ jobs:
       REGISTRY: ghcr.io
       IMAGE_PREFIX: ghcr.io/${{ github.repository }}
       UI_HOST_PORT: 3001
+      GATEWAY_HOST_PORT: 8081
+      GATEWAY_HOST_IP: 127.0.0.1
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -125,13 +127,15 @@ jobs:
           GITHUB_ACTOR: ${{ github.actor }}
           DEPLOY_APP_DIR: ${{ secrets.DEPLOY_APP_DIR }}
           UI_HOST_PORT: ${{ env.UI_HOST_PORT }}
+          GATEWAY_HOST_PORT: ${{ env.GATEWAY_HOST_PORT }}
+          GATEWAY_HOST_IP: ${{ env.GATEWAY_HOST_IP }}
         with:
           host: ${{ secrets.DEPLOY_HOST }}
           username: ${{ secrets.DEPLOY_USER }}
           port: ${{ secrets.DEPLOY_PORT }}
           key: ${{ secrets.DEPLOY_SSH_KEY }}
           fingerprint: ${{ secrets.DEPLOY_FINGERPRINT }}
-          envs: IMAGE_PREFIX,NEXT_PUBLIC_GATEWAY_URL,NEXT_PUBLIC_API_BASE_URL,NEXT_PUBLIC_WS_URL,NEXT_PUBLIC_ENABLE_FULL_UI,TARGET_RPC_URL,TARGET_WS_URL,TARGET_HEALTH_PATH,HEALTH_TIMEOUT_MS,GATEWAY_ALLOWED_ORIGINS,GITHUB_TOKEN,GITHUB_ACTOR,DEPLOY_APP_DIR,UI_HOST_PORT
+          envs: IMAGE_PREFIX,NEXT_PUBLIC_GATEWAY_URL,NEXT_PUBLIC_API_BASE_URL,NEXT_PUBLIC_WS_URL,NEXT_PUBLIC_ENABLE_FULL_UI,TARGET_RPC_URL,TARGET_WS_URL,TARGET_HEALTH_PATH,HEALTH_TIMEOUT_MS,GATEWAY_ALLOWED_ORIGINS,GITHUB_TOKEN,GITHUB_ACTOR,DEPLOY_APP_DIR,UI_HOST_PORT,GATEWAY_HOST_PORT,GATEWAY_HOST_IP
           script: |
             set -euo pipefail
             if command -v sudo >/dev/null 2>&1; then
@@ -155,6 +159,8 @@ jobs:
 
             IMAGE_PREFIX="${IMAGE_PREFIX,,}"
             : "${UI_HOST_PORT:=3001}"
+            : "${GATEWAY_HOST_PORT:=8081}"
+            : "${GATEWAY_HOST_IP:=127.0.0.1}"
             : "${NEXT_PUBLIC_GATEWAY_URL:=https://ui.ippan.org/api}"
             : "${NEXT_PUBLIC_API_BASE_URL:=${NEXT_PUBLIC_GATEWAY_URL}}"
             : "${NEXT_PUBLIC_WS_URL:=wss://ui.ippan.org/ws}"
@@ -215,7 +221,7 @@ jobs:
                 depends_on:
                   - node
                 ports:
-                  - "127.0.0.1:8080:8080"
+                  - "${GATEWAY_HOST_IP:-127.0.0.1}:${GATEWAY_HOST_PORT:-8081}:8080"
               node:
                 image: ${IMAGE_PREFIX}/node:latest
                 env_file:
@@ -242,6 +248,8 @@ jobs:
             TARGET_HEALTH_PATH=${TARGET_HEALTH_PATH}
             HEALTH_TIMEOUT_MS=${HEALTH_TIMEOUT_MS}
             ALLOWED_ORIGINS=${GATEWAY_ALLOWED_ORIGINS}
+            GATEWAY_HOST_PORT=${GATEWAY_HOST_PORT}
+            GATEWAY_HOST_IP=${GATEWAY_HOST_IP}
             ENV
 
             if [ -n "$SUDO" ]; then
@@ -269,7 +277,7 @@ jobs:
               }
 
               location /api/ {
-                proxy_pass http://127.0.0.1:8080/;
+                proxy_pass http://${GATEWAY_HOST_IP}:${GATEWAY_HOST_PORT}/;
                 proxy_set_header Host \$host;
                 proxy_set_header X-Forwarded-For \$remote_addr;
                 proxy_set_header X-Forwarded-Proto https;
@@ -277,7 +285,7 @@ jobs:
               }
 
               location /ws/ {
-                proxy_pass http://127.0.0.1:8080/ws/;
+                proxy_pass http://${GATEWAY_HOST_IP}:${GATEWAY_HOST_PORT}/ws/;
                 proxy_http_version 1.1;
                 proxy_set_header Upgrade \$http_upgrade;
                 proxy_set_header Connection "upgrade";
@@ -330,30 +338,50 @@ jobs:
 
             free_port() {
               local port="$1"
+              echo "Checking port $port"
+              (command -v ss >/dev/null 2>&1 && ss -ltnp | grep ":${port}" || true)
+              (command -v lsof >/dev/null 2>&1 && lsof -i :"$port" || true)
+
               local pids=""
+              if command -v lsof >/dev/null 2>&1; then
+                pids="$(lsof -ti :"$port" 2>/dev/null || true)"
+                if [ -n "$pids" ]; then
+                  echo "Killing PIDs with lsof: $pids"
+                  if [ -n "$SUDO" ]; then
+                    run_root kill -9 $pids 2>/dev/null || true
+                  else
+                    kill -9 $pids 2>/dev/null || true
+                  fi
+                fi
+              fi
+
               if command -v fuser >/dev/null 2>&1; then
                 if [ -n "$SUDO" ]; then
                   run_root fuser -k "${port}/tcp" 2>/dev/null || true
                 else
                   fuser -k "${port}/tcp" 2>/dev/null || true
                 fi
-              elif command -v lsof >/dev/null 2>&1; then
+              fi
+
+              if command -v docker >/dev/null 2>&1; then
+                local cid
                 if [ -n "$SUDO" ]; then
-                  pids="$(run_root lsof -ti:"$port" 2>/dev/null || true)"
-                  if [ -n "$pids" ]; then
-                    run_root kill -9 $pids 2>/dev/null || true
-                  fi
+                  cid="$(run_root docker ps -q --filter "publish=${port}" 2>/dev/null || true)"
                 else
-                  pids="$(lsof -ti:"$port" 2>/dev/null || true)"
-                  if [ -n "$pids" ]; then
-                    kill -9 $pids 2>/dev/null || true
+                  cid="$(docker ps -q --filter "publish=${port}" 2>/dev/null || true)"
+                fi
+                if [ -n "$cid" ]; then
+                  echo "Stopping containers publishing $port: $cid"
+                  if [ -n "$SUDO" ]; then
+                    for c in $cid; do run_root docker stop "$c" || true; done
+                  else
+                    for c in $cid; do docker stop "$c" || true; done
                   fi
                 fi
-              else
-                echo "::warning::Neither fuser nor lsof found; skipping port $port cleanup"
               fi
             }
 
+            free_port "$GATEWAY_HOST_PORT"
             free_port "$UI_HOST_PORT"
 
             $DC pull

--- a/.github/workflows/deploy-unified-ui.yml
+++ b/.github/workflows/deploy-unified-ui.yml
@@ -19,6 +19,8 @@ jobs:
     env:
       REGISTRY: ghcr.io
       IMAGE_PREFIX: ghcr.io/${{ github.repository }}
+      GATEWAY_HOST_PORT: 8081
+      GATEWAY_HOST_IP: 127.0.0.1
 
     steps:
       - name: Checkout repository
@@ -126,13 +128,15 @@ jobs:
           GATEWAY_ALLOWED_ORIGINS: ${{ secrets.GATEWAY_ALLOWED_ORIGINS }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITHUB_ACTOR: ${{ github.actor }}
+          GATEWAY_HOST_PORT: ${{ env.GATEWAY_HOST_PORT }}
+          GATEWAY_HOST_IP: ${{ env.GATEWAY_HOST_IP }}
         with:
           host: ${{ secrets.DEPLOY_HOST }}
           username: ${{ secrets.DEPLOY_USER }}
           port: ${{ secrets.DEPLOY_PORT }}
           key: ${{ secrets.DEPLOY_SSH_KEY }}
           fingerprint: ${{ secrets.DEPLOY_FINGERPRINT }}
-          envs: IMAGE_PREFIX,NEXT_PUBLIC_GATEWAY_URL,NEXT_PUBLIC_API_BASE_URL,NEXT_PUBLIC_WS_URL,NEXT_PUBLIC_ENABLE_FULL_UI,TARGET_RPC_URL,TARGET_WS_URL,TARGET_HEALTH_PATH,HEALTH_TIMEOUT_MS,GATEWAY_ALLOWED_ORIGINS,GITHUB_TOKEN,GITHUB_ACTOR
+          envs: IMAGE_PREFIX,NEXT_PUBLIC_GATEWAY_URL,NEXT_PUBLIC_API_BASE_URL,NEXT_PUBLIC_WS_URL,NEXT_PUBLIC_ENABLE_FULL_UI,TARGET_RPC_URL,TARGET_WS_URL,TARGET_HEALTH_PATH,HEALTH_TIMEOUT_MS,GATEWAY_ALLOWED_ORIGINS,GITHUB_TOKEN,GITHUB_ACTOR,GATEWAY_HOST_PORT,GATEWAY_HOST_IP
           script_stop: true
           script: |
             set -euo pipefail
@@ -141,6 +145,8 @@ jobs:
             sudo -n true >/dev/null 2>&1 || { echo "::error::Passwordless sudo missing. Run bootstrap_deploy_user.sh"; exit 1; }
 
             IMAGE_PREFIX="${IMAGE_PREFIX,,}"
+            : "${GATEWAY_HOST_PORT:=8081}"
+            : "${GATEWAY_HOST_IP:=127.0.0.1}"
             : "${NEXT_PUBLIC_GATEWAY_URL:=https://ui.ippan.org/api}"
             : "${NEXT_PUBLIC_API_BASE_URL:=${NEXT_PUBLIC_GATEWAY_URL}}"
             : "${NEXT_PUBLIC_WS_URL:=wss://ui.ippan.org/ws}"
@@ -171,7 +177,7 @@ jobs:
                 restart: unless-stopped
                 networks: [web]
                 depends_on: [node]
-                ports: ["127.0.0.1:8080:8080"]
+                ports: ["${GATEWAY_HOST_IP:-127.0.0.1}:${GATEWAY_HOST_PORT:-8081}:8080"]
               node:
                 image: ${IMAGE_PREFIX}/node:latest
                 env_file: [.env]
@@ -194,15 +200,17 @@ jobs:
             TARGET_HEALTH_PATH=${TARGET_HEALTH_PATH:-}
             HEALTH_TIMEOUT_MS=${HEALTH_TIMEOUT_MS:-}
             ALLOWED_ORIGINS=${GATEWAY_ALLOWED_ORIGINS:-}
+            GATEWAY_HOST_PORT=${GATEWAY_HOST_PORT}
+            GATEWAY_HOST_IP=${GATEWAY_HOST_IP}
             ENV
 
             # Nginx reverse proxy
             sudo install -d -m 755 /etc/nginx/sites-available /etc/nginx/sites-enabled
-            cat <<'NGINX' | sudo tee /etc/nginx/sites-available/ui.ippan.org >/dev/null
+            cat <<NGINX | sudo tee /etc/nginx/sites-available/ui.ippan.org >/dev/null
             server {
               listen 80;
               server_name ui.ippan.org;
-              return 301 https://$host$request_uri;
+              return 301 https://\$host\$request_uri;
             }
             server {
               listen 443 ssl http2;
@@ -213,28 +221,57 @@ jobs:
 
               location / {
                 proxy_pass http://127.0.0.1:3000;
-                proxy_set_header Host $host;
-                proxy_set_header X-Forwarded-For $remote_addr;
+                proxy_set_header Host \$host;
+                proxy_set_header X-Forwarded-For \$remote_addr;
                 proxy_set_header X-Forwarded-Proto https;
               }
               location /api/ {
-                proxy_pass http://127.0.0.1:8080/;
-                proxy_set_header Host $host;
-                proxy_set_header X-Forwarded-For $remote_addr;
+                proxy_pass http://${GATEWAY_HOST_IP}:${GATEWAY_HOST_PORT}/;
+                proxy_set_header Host \$host;
+                proxy_set_header X-Forwarded-For \$remote_addr;
                 proxy_set_header X-Forwarded-Proto https;
               }
               location /ws/ {
-                proxy_pass http://127.0.0.1:8080/ws/;
+                proxy_pass http://${GATEWAY_HOST_IP}:${GATEWAY_HOST_PORT}/ws/;
                 proxy_http_version 1.1;
-                proxy_set_header Upgrade $http_upgrade;
+                proxy_set_header Upgrade \$http_upgrade;
                 proxy_set_header Connection "upgrade";
-                proxy_set_header Host $host;
+                proxy_set_header Host \$host;
               }
             }
             NGINX
             sudo ln -sf /etc/nginx/sites-available/ui.ippan.org /etc/nginx/sites-enabled/ui.ippan.org
             sudo nginx -t
             sudo systemctl reload nginx || sudo nginx -s reload
+
+            free_port() {
+              local port="$1"
+              echo "Checking port $port"
+              (command -v ss >/dev/null 2>&1 && ss -ltnp | grep ":${port}" || true)
+              (command -v lsof >/dev/null 2>&1 && lsof -i :"$port" || true)
+
+              local pids=""
+              if command -v lsof >/dev/null 2>&1; then
+                pids="$(lsof -ti :"$port" 2>/dev/null || true)"
+                if [ -n "$pids" ]; then
+                  echo "Killing PIDs with lsof: $pids"
+                  sudo kill -9 $pids 2>/dev/null || true
+                fi
+              fi
+
+              if command -v fuser >/dev/null 2>&1; then
+                sudo fuser -k "${port}/tcp" 2>/dev/null || true
+              fi
+
+              if command -v docker >/dev/null 2>&1; then
+                local cid
+                cid="$(sudo docker ps -q --filter "publish=${port}" 2>/dev/null || true)"
+                if [ -n "$cid" ]; then
+                  echo "Stopping containers publishing $port: $cid"
+                  for c in $cid; do sudo docker stop "$c" || true; done
+                fi
+              fi
+            }
 
             # Ensure docker compose available
             if docker compose version >/dev/null 2>&1; then
@@ -255,6 +292,7 @@ jobs:
             fi
 
             # Pull and update stack
+            free_port "$GATEWAY_HOST_PORT"
             $DC pull
             $DC down --remove-orphans || true
 
@@ -272,7 +310,7 @@ jobs:
               [ "$(date +%s)" -lt "$deadline" ] || { echo "::error::UI health check failed"; exit 1; }
               sleep 1
             done
-            until curl -fsS http://127.0.0.1:8080${TARGET_HEALTH_PATH:-/health} >/dev/null 2>&1; do
+            until curl -fsS http://${GATEWAY_HOST_IP}:${GATEWAY_HOST_PORT}${TARGET_HEALTH_PATH:-/health} >/dev/null 2>&1; do
               [ "$(date +%s)" -lt "$deadline" ] || { echo "::error::Gateway health check failed"; exit 1; }
               sleep 1
             done

--- a/deploy/server/docker-compose.yml
+++ b/deploy/server/docker-compose.yml
@@ -14,7 +14,7 @@ services:
     depends_on:
       - node
     ports:
-      - "127.0.0.1:8080:8080"
+      - "${GATEWAY_HOST_IP:-127.0.0.1}:${GATEWAY_HOST_PORT:-8081}:8080"
   node:
     image: ghcr.io/OWNER/REPO/node:latest
     env_file: .env

--- a/deploy/server/nginx-ui.ippan.org.conf
+++ b/deploy/server/nginx-ui.ippan.org.conf
@@ -20,7 +20,7 @@ server {
   }
 
   location /api/ {
-    proxy_pass http://127.0.0.1:8080/;
+    proxy_pass http://127.0.0.1:8081/;
     proxy_set_header Host $host;
     proxy_set_header X-Forwarded-For $remote_addr;
     proxy_set_header X-Forwarded-Proto https;
@@ -28,7 +28,7 @@ server {
   }
 
   location /ws/ {
-    proxy_pass http://127.0.0.1:8080/ws/;
+    proxy_pass http://127.0.0.1:8081/ws/;
     proxy_http_version 1.1;
     proxy_set_header Upgrade $http_upgrade;
     proxy_set_header Connection "upgrade";

--- a/deployments/nginx/nginx.conf
+++ b/deployments/nginx/nginx.conf
@@ -50,7 +50,7 @@ http {
 
     # Upstream backend
     upstream ippan_backend {
-        server 127.0.0.1:8080;
+        server 127.0.0.1:8081;
         keepalive 32;
     }
 


### PR DESCRIPTION
## Summary
- add configurable gateway host IP/port defaults in the deploy workflows and generated compose/nginx configs
- add best-effort port  cleanup before bringing the stack up to avoid conflicts
- update server deployment templates to match the new gateway port default

## Testing
- not run (workflow change only)


------
https://chatgpt.com/codex/tasks/task_e_68dfeaa3a32c832ba8cf85cfb2d3bba7