### PR TITLE
Implement IPPAN round finalization persistence

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1220,6 +1220,7 @@ name = "ippan-consensus"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "blake3",
  "ed25519-dalek",
  "futures",
  "hex",

--- a/crates/consensus/Cargo.toml
+++ b/crates/consensus/Cargo.toml
@@ -21,6 +21,7 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 futures = { workspace = true }
 parking_lot = { workspace = true }
+blake3 = { workspace = true }
 
 [dev-dependencies]
 ed25519-dalek = { workspace = true }

--- a/crates/types/src/round.rs
+++ b/crates/types/src/round.rs
@@ -24,6 +24,7 @@ pub struct RoundCertificate {
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
 pub struct RoundFinalizationRecord {
     pub round: RoundId,
+    pub window: RoundWindow,
     pub ordered_tx_ids: Vec<[u8; 32]>,
     pub fork_drops: Vec<[u8; 32]>,
     pub state_root: [u8; 32],


### PR DESCRIPTION
## Summary
- add round window metadata to finalization records as described in the PRD
- persist round certificates and finalization records in sled and memory storage backends with coverage tests
- extend PoA consensus finalization to aggregate certificates, derive state roots, and record round outcomes

## Testing
- cargo test

------
https://chatgpt.com/codex/tasks/task_e_68e02afc838c832b9a4517227e0a7ce9