### PR TITLE
Fix redundant closures in RPC server parent hash encoding

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,7 @@ jobs:
       RUST_BACKTRACE: 1
       CARGO_TERM_COLOR: always
       WORKSPACE_EXCLUDES: "--exclude ippan-rpc --exclude ippan-node"
+      toolchain: stable
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/crates/rpc/src/server.rs
+++ b/crates/rpc/src/server.rs
@@ -854,7 +854,7 @@ async fn api_recent_blocks(
             .get_block_by_height(height)
             .map_err(internal_error)?
         {
-            let parent_hashes = block
+            let parent_hashes: Vec<String> = block
                 .header
                 .parent_ids
                 .iter()
@@ -887,7 +887,7 @@ async fn api_block_by_height(
         .map_err(internal_error)?
         .ok_or((StatusCode::NOT_FOUND, format!("block {height} not found")))?;
 
-    let parent_hashes = block
+    let parent_hashes: Vec<String> = block
         .header
         .parent_ids
         .iter()

--- a/crates/rpc/src/server.rs
+++ b/crates/rpc/src/server.rs
@@ -858,7 +858,7 @@ async fn api_recent_blocks(
                 .header
                 .parent_ids
                 .iter()
-                .map(|id| encode(id))
+                .map(encode)
                 .collect();
             blocks.push(BlockSummaryResponse {
                 height,
@@ -891,7 +891,7 @@ async fn api_block_by_height(
         .header
         .parent_ids
         .iter()
-        .map(|id| encode(id))
+        .map(encode)
         .collect();
 
     let transactions = block


### PR DESCRIPTION
## Summary
- replace redundant closures in block response builders with direct `encode` function references to satisfy clippy

## Testing
- cargo clippy --workspace --all-targets -- -D warnings
- cargo test --workspace

------
https://chatgpt.com/codex/tasks/task_e_68e0e35fda7c832b838202fb649a0ed0