### PR TITLE
Ensure UI fetch calls use configured API base

### DIFF
--- a/apps/unified-ui/src/components/ValidatorRegistrationModal.tsx
+++ b/apps/unified-ui/src/components/ValidatorRegistrationModal.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react'
 import { Modal, Button, Field, Input, LoadingSpinner } from './UI'
 import { useToast } from './Toast'
+import { buildApiUrl } from '../lib/api'
 
 interface ValidatorRegistrationModalProps {
   isOpen: boolean
@@ -90,7 +91,7 @@ export default function ValidatorRegistrationModal({
     setError(null)
 
     try {
-      const response = await fetch('/api/v1/validators/register', {
+      const response = await fetch(buildApiUrl('/api/v1/validators/register'), {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',

--- a/apps/unified-ui/src/lib/api.ts
+++ b/apps/unified-ui/src/lib/api.ts
@@ -47,6 +47,17 @@ export function getApiBaseUrl() {
   return API_BASE_URL;
 }
 
+export function buildApiUrl(path: string): string {
+  if (!path) {
+    return getApiBaseUrl();
+  }
+
+  const normalizedBase = getApiBaseUrl().replace(/\/$/, '');
+  const normalizedPath = path.startsWith('/') ? path : `/${path}`;
+
+  return `${normalizedBase}${normalizedPath}`;
+}
+
 export function initializeApiBaseUrl(): string {
   if (typeof window !== 'undefined') {
     const stored = readStoredBaseUrl();

--- a/apps/unified-ui/src/pages/FileAvailabilityPage.tsx
+++ b/apps/unified-ui/src/pages/FileAvailabilityPage.tsx
@@ -1,5 +1,6 @@
 import { useState, useEffect } from 'react'
 import { Card, Button, Input, Badge, Select, SelectTrigger, SelectValue, SelectContent, SelectItem } from '../components/UI'
+import { buildApiUrl } from '../lib/api'
 
 // Types for network file availability
 type FileStatus = 
@@ -267,12 +268,15 @@ export default function FileAvailabilityPage() {
       }
       
       // Call API to initiate download
-      const response = await fetch(`/api/v1/availability/files/${file.id}/download?requester=current_user`, {
-        method: 'GET',
-        headers: {
-          'Content-Type': 'application/json',
-        },
-      })
+      const response = await fetch(
+        buildApiUrl(`/api/v1/availability/files/${file.id}/download?requester=current_user`),
+        {
+          method: 'GET',
+          headers: {
+            'Content-Type': 'application/json',
+          },
+        }
+      )
       
       if (response.ok) {
         const data = await response.json()

--- a/apps/unified-ui/src/pages/InteroperabilityPage.tsx
+++ b/apps/unified-ui/src/pages/InteroperabilityPage.tsx
@@ -1,6 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import { Card, Button, Badge, LoadingSpinner, Modal, Field, Input } from '../components/UI';
 import { useToast } from '../components/Toast';
+import { buildApiUrl } from '../lib/api';
 
 interface L2Network {
   id: string;
@@ -145,7 +146,7 @@ export default function InteroperabilityPage() {
         throw new Error('Epoch must be a positive number');
       }
 
-      const response = await fetch('/api/v1/l2/commit', {
+      const response = await fetch(buildApiUrl('/api/v1/l2/commit'), {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
@@ -208,7 +209,7 @@ export default function InteroperabilityPage() {
       }
 
       // Submit to API
-      const response = await fetch('/api/v1/l2/verify_exit', {
+      const response = await fetch(buildApiUrl('/api/v1/l2/verify_exit'), {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',


### PR DESCRIPTION
## Summary
- add a helper for constructing API URLs from the configured base
- use the helper for validator registration, interoperability, and file availability fetch calls

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e0e3fe796c832b962b61937de896f6