### PR TITLE
Ensure deploy UI workflow respects build env secrets

### DIFF
--- a/.github/workflows/deploy-ui.yml
+++ b/.github/workflows/deploy-ui.yml
@@ -33,23 +33,43 @@ jobs:
           node-version: '20'
 
       - name: Sanity-check UI build env
+        if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
         working-directory: apps/unified-ui
+        env:
+          NEXT_PUBLIC_ENABLE_FULL_UI: ${{ secrets.NEXT_PUBLIC_ENABLE_FULL_UI || vars.NEXT_PUBLIC_ENABLE_FULL_UI }}
+          NEXT_PUBLIC_GATEWAY_URL: ${{ secrets.NEXT_PUBLIC_GATEWAY_URL || vars.NEXT_PUBLIC_GATEWAY_URL }}
+          NEXT_PUBLIC_API_BASE_URL: ${{ secrets.NEXT_PUBLIC_API_BASE_URL || vars.NEXT_PUBLIC_API_BASE_URL }}
+          NEXT_PUBLIC_WS_URL: ${{ secrets.NEXT_PUBLIC_WS_URL || vars.NEXT_PUBLIC_WS_URL }}
         run: |
           set -euo pipefail
-          for v in NEXT_PUBLIC_GATEWAY_URL NEXT_PUBLIC_API_BASE_URL NEXT_PUBLIC_WS_URL NEXT_PUBLIC_ENABLE_FULL_UI; do
-            if [ -z "${!v:-}" ]; then
-              echo "::error::$v is empty. Set it in Settings → Secrets and variables → Actions."
-              exit 1
-            fi
+
+          # Mask values to avoid leaking them in logs
+          for v in NEXT_PUBLIC_ENABLE_FULL_UI NEXT_PUBLIC_GATEWAY_URL NEXT_PUBLIC_API_BASE_URL NEXT_PUBLIC_WS_URL; do
+            echo "::add-mask::${!v:-}"
           done
+
+          require() {
+            local name="$1" val="${!1:-}"
+            if [ -z "$val" ]; then
+              echo "❌ $name is empty or undefined"
+              exit 1
+            else
+              echo "✅ $name is set"
+            fi
+          }
+
+          require NEXT_PUBLIC_ENABLE_FULL_UI
+          require NEXT_PUBLIC_GATEWAY_URL
+          require NEXT_PUBLIC_API_BASE_URL
+          require NEXT_PUBLIC_WS_URL
 
       - name: Install and build Unified UI
         working-directory: apps/unified-ui
         env:
-          NEXT_PUBLIC_GATEWAY_URL: ${{ secrets.NEXT_PUBLIC_GATEWAY_URL }}
-          NEXT_PUBLIC_API_BASE_URL: ${{ secrets.NEXT_PUBLIC_API_BASE_URL }}
-          NEXT_PUBLIC_WS_URL: ${{ secrets.NEXT_PUBLIC_WS_URL }}
-          NEXT_PUBLIC_ENABLE_FULL_UI: ${{ secrets.NEXT_PUBLIC_ENABLE_FULL_UI }}
+          NEXT_PUBLIC_ENABLE_FULL_UI: ${{ secrets.NEXT_PUBLIC_ENABLE_FULL_UI || vars.NEXT_PUBLIC_ENABLE_FULL_UI }}
+          NEXT_PUBLIC_GATEWAY_URL: ${{ secrets.NEXT_PUBLIC_GATEWAY_URL || vars.NEXT_PUBLIC_GATEWAY_URL }}
+          NEXT_PUBLIC_API_BASE_URL: ${{ secrets.NEXT_PUBLIC_API_BASE_URL || vars.NEXT_PUBLIC_API_BASE_URL }}
+          NEXT_PUBLIC_WS_URL: ${{ secrets.NEXT_PUBLIC_WS_URL || vars.NEXT_PUBLIC_WS_URL }}
         run: |
           set -euo pipefail
           : "${NEXT_PUBLIC_GATEWAY_URL:=https://ui.ippan.org/api}"


### PR DESCRIPTION
## Summary
- load public UI environment variables from secrets or repo variables during deploy builds
- mask the variables when sanity-checking and skip the check for forked pull requests
- reuse the same environment resolution for the Unified UI build step

## Testing
- not run (workflow change only)

------
https://chatgpt.com/codex/tasks/task_e_68e3a322b9bc832bba1d1c127ce2fd25