### PR TITLE
Harden IPPAN node checks

### DIFF
--- a/.github/workflows/check-nodes.yml
+++ b/.github/workflows/check-nodes.yml
@@ -1,0 +1,85 @@
+name: Check IPPAN Nodes
+
+on:
+  workflow_dispatch:
+    inputs:
+      hosts:
+        description: "Comma-separated IPv4/hostnames"
+        required: true
+        default: "188.245.97.41,188.245.97.42"
+      ui_url:
+        description: "Public UI URL (optional)"
+        required: false
+        default: "https://ui.ippan.org"
+      api_base:
+        description: "Node API base (as seen on target)"
+        required: false
+        default: "http://127.0.0.1:8080"
+      lb_health:
+        description: "Load balancer health URL on target"
+        required: false
+        default: "http://127.0.0.1:3000/lb-health"
+  schedule:
+    # Optional nightly check at 02:30 Europe/Rome
+    - cron: "30 0 * * *"
+
+env:
+  DEFAULT_HOSTS: "188.245.97.41,188.245.97.42"
+  DEFAULT_UI_URL: "https://ui.ippan.org"
+  DEFAULT_API_BASE: "http://127.0.0.1:8080"
+  DEFAULT_LB_HEALTH: "http://127.0.0.1:3000/lb-health"
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    env:
+      SSH_USER: ${{ secrets.PROD_SSH_USER }}
+      SSH_KEY: ${{ secrets.PROD_SSH_KEY }}          # OpenSSH private key
+      SSH_PORT: ${{ secrets.PROD_SSH_PORT || 22 }}
+      SYSTEMD_SVC: ippan-node
+      DOCKER_COMPOSE_DIR: /opt/ippan
+      P2P_PORTS: 4001,7000,8080,3000
+      DEFAULT_HOSTS: ${{ env.DEFAULT_HOSTS }}
+      DEFAULT_UI_URL: ${{ env.DEFAULT_UI_URL }}
+      DEFAULT_API_BASE: ${{ env.DEFAULT_API_BASE }}
+      DEFAULT_LB_HEALTH: ${{ env.DEFAULT_LB_HEALTH }}
+    strategy:
+      fail-fast: false
+      matrix:
+        host: ${{ fromJson(format('["{0}"]', join('\",\"', split(replace(inputs.hosts || env.DEFAULT_HOSTS, ' ', ''), ',')))) }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Prepare SSH key
+        run: |
+          install -m 700 -d ~/.ssh
+          echo "${SSH_KEY}" > ~/.ssh/id_ed25519
+          chmod 600 ~/.ssh/id_ed25519
+          printf "Host *\n\tStrictHostKeyChecking no\n" > ~/.ssh/config
+
+      - name: Copy checker script
+        run: |
+          rsync -e "ssh -i ~/.ssh/id_ed25519 -p ${SSH_PORT}" -avz deploy/check-nodes.sh "${SSH_USER}@${{ matrix.host }}:/tmp/check-nodes.sh"
+          ssh -i ~/.ssh/id_ed25519 -p ${SSH_PORT} "${SSH_USER}@${{ matrix.host }}" "chmod +x /tmp/check-nodes.sh"
+
+      - name: Run checks on ${{ matrix.host }}
+        id: run_checks
+        env:
+          HOST: ${{ matrix.host }}
+          UI_URL: ${{ inputs.ui_url || env.DEFAULT_UI_URL }}
+          API_BASE: ${{ inputs.api_base || env.DEFAULT_API_BASE }}
+          LB_HEALTH: ${{ inputs.lb_health || env.DEFAULT_LB_HEALTH }}
+        run: |
+          set -euo pipefail
+          api_base="${API_BASE%/}"
+          ssh -i ~/.ssh/id_ed25519 -p ${SSH_PORT} "${SSH_USER}@${{ matrix.host }}" \
+            "HOST='$HOST' UI_URL='$UI_URL' API_BASE='$api_base' LB_HEALTH='${LB_HEALTH}' HTTP_HEALTH='${api_base}/health' HTTP_STATUS='${api_base}/status' HTTP_PEERS='${api_base}/peers' SYSTEMD_SVC='${SYSTEMD_SVC}' DOCKER_COMPOSE_DIR='${DOCKER_COMPOSE_DIR}' P2P_PORTS='${P2P_PORTS}' /tmp/check-nodes.sh" \
+            | tee "summary-${{ matrix.host }}.json"
+
+      - name: Upload summaries
+        uses: actions/upload-artifact@v4
+        with:
+          name: node-summaries
+          path: summary-*.json

--- a/deploy/check-nodes.sh
+++ b/deploy/check-nodes.sh
@@ -1,0 +1,185 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Usage:
+#   HOST="188.245.97.41" UI_URL="https://ui.ippan.org" API_BASE="http://127.0.0.1:8080" ./deploy/check-nodes.sh
+# or pass via env; defaults try common ports.
+
+HOST="${HOST:-}"
+UI_URL="${UI_URL:-}"
+API_BASE="${API_BASE:-http://127.0.0.1:8080}"
+LB_HEALTH="${LB_HEALTH:-http://127.0.0.1:3000/lb-health}"
+HTTP_HEALTH="${HTTP_HEALTH:-$API_BASE/health}"
+HTTP_STATUS="${HTTP_STATUS:-$API_BASE/status}"
+HTTP_PEERS="${HTTP_PEERS:-$API_BASE/peers}"
+P2P_PORTS="${P2P_PORTS:-4001,7000,8080,3000}"
+SYSTEMD_SVC="${SYSTEMD_SVC:-ippan-node}"
+DOCKER_COMPOSE_DIR="${DOCKER_COMPOSE_DIR:-/opt/ippan}"
+
+if [[ -z "$HOST" ]]; then
+  echo "HOST env is required" >&2
+  exit 2
+fi
+
+# Helper
+json_escape() {
+  JSON_VALUE="$1" python3 - <<'PY'
+import json
+import os
+
+print(json.dumps(os.environ.get("JSON_VALUE", "")))
+PY
+}
+
+check_cmd() {
+  local cmd="$1"
+  if eval "$cmd" >/dev/null 2>&1; then echo "ok"; else echo "fail"; fi
+}
+
+echo "== Checking host $HOST =="
+
+# 1) Basic reachability (from the host itself)
+IP_ADDR="$(hostname -I 2>/dev/null | awk '{print $1}')"
+DATE_NOW="$(date -u +"%Y-%m-%dT%H:%M:%SZ" 2>/dev/null || true)"
+
+# 2) Service presence (systemd or docker)
+SYSTEMD_PRESENT="$(check_cmd "systemctl status $SYSTEMD_SVC")"
+DOCKER_PRESENT="$(check_cmd "docker ps")"
+
+if [[ "$SYSTEMD_PRESENT" == "ok" ]]; then
+  SYSTEMD_ACTIVE="$(systemctl is-active "$SYSTEMD_SVC" 2>/dev/null || true)"
+else
+  SYSTEMD_ACTIVE="n/a"
+fi
+
+if [[ "$DOCKER_PRESENT" == "ok" ]]; then
+  # If using docker compose
+  if [[ -d "$DOCKER_COMPOSE_DIR" ]]; then
+    pushd "$DOCKER_COMPOSE_DIR" >/dev/null || true
+    DOCKER_PS="$(docker compose ps --status running 2>/dev/null || true)"
+    popd >/dev/null || true
+  else
+    DOCKER_PS="$(docker ps --format '{{.Names}} {{.Ports}}' 2>/dev/null || true)"
+  fi
+else
+  DOCKER_PS="docker-not-installed"
+fi
+
+# 3) Ports listening
+declare -a OPEN_PORTS=()
+IFS=',' read -r -a PORTS <<< "$P2P_PORTS"
+for p in "${PORTS[@]}"; do
+  if ss -ltn "( sport = :$p )" 2>/dev/null | grep -q ":$p"; then
+    OPEN_PORTS+=("$p")
+  fi
+done
+
+open_ports_json="[]"
+if ((${#OPEN_PORTS[@]})); then
+  open_ports_json="[${OPEN_PORTS[0]}"
+  for port in "${OPEN_PORTS[@]:1}"; do
+    open_ports_json+=",$port"
+  done
+  open_ports_json+="]"
+fi
+
+# 4) HTTP/LB/Health checks
+http_code() {
+  curl -sS -o /dev/null -w "%{http_code}" "$1" || echo "000"
+}
+hc_api="$(http_code "$HTTP_HEALTH")"
+hc_status="$(http_code "$HTTP_STATUS")"
+hc_peers="$(http_code "$HTTP_PEERS")"
+hc_lb="$(http_code "$LB_HEALTH")"
+
+# 5) Fetch details (don’t fail pipeline if endpoints absent)
+get_json() {
+  curl -sS --max-time 5 "$1" || echo "{}"
+}
+status_json="$(get_json "$HTTP_STATUS")"
+peers_json="$(get_json "$HTTP_PEERS")"
+
+extract_version() {
+  STATUS_JSON="$1" python3 - <<'PY'
+import json
+import os
+
+raw = os.environ.get("STATUS_JSON", "{}")
+try:
+    data = json.loads(raw)
+except Exception:
+    print("unknown")
+else:
+    print(data.get("version") or data.get("build") or "unknown")
+PY
+}
+
+extract_peer_count() {
+  PEERS_JSON="$1" python3 - <<'PY'
+import json
+import os
+
+raw = os.environ.get("PEERS_JSON", "{}")
+try:
+    data = json.loads(raw)
+except Exception:
+    print(0)
+else:
+    peers = data.get("peers")
+    try:
+        print(len(peers))
+    except TypeError:
+        print(0)
+PY
+}
+
+# 6) Derive simple metrics
+version="$(extract_version "$status_json")"
+peer_count="$(extract_peer_count "$peers_json")"
+
+if ! [[ "$peer_count" =~ ^[0-9]+$ ]]; then
+  peer_count=0
+fi
+
+# 7) Optional UI check
+if [[ -n "$UI_URL" ]]; then
+  ui_code="$(http_code "$UI_URL")"
+else
+  ui_code="(skipped)"
+fi
+
+# 8) Output summary JSON
+summary="$(cat <<EOF
+{
+  "timestamp": $(json_escape "$DATE_NOW"),
+  "host": $(json_escape "$HOST"),
+  "ip": $(json_escape "${IP_ADDR:-unknown}"),
+  "systemd_present": $(json_escape "$SYSTEMD_PRESENT"),
+  "systemd_active": $(json_escape "$SYSTEMD_ACTIVE"),
+  "docker_present": $(json_escape "$DOCKER_PRESENT"),
+  "docker_ps": $(json_escape "$DOCKER_PS"),
+  "open_ports": $open_ports_json,
+  "endpoints": {
+    "health_code": $(json_escape "$hc_api"),
+    "status_code": $(json_escape "$hc_status"),
+    "peers_code": $(json_escape "$hc_peers"),
+    "lb_code": $(json_escape "$hc_lb"),
+    "ui_code": $(json_escape "$ui_code")
+  },
+  "version": $(json_escape "$version"),
+  "peer_count": $peer_count,
+  "status_sample": $status_json,
+  "peers_sample": $peers_json
+}
+EOF
+)"
+echo "$summary"
+
+# 9) Fail if critical checks fail
+fail=0
+[[ "$hc_api" == "200" ]] || fail=1
+[[ "$hc_status" == "200" ]] || fail=1
+[[ "$hc_peers" == "200" ]] || fail=1
+[[ "$peer_count" =~ ^[1-9][0-9]*$ ]] || fail=1
+
+exit $fail


### PR DESCRIPTION
## Summary
- remove the jq dependency from deploy/check-nodes.sh by switching to small Python helpers for JSON escaping and metrics extraction
- ensure the workflow builds API URLs at runtime, trims host entries, and exposes default inputs for scheduled runs

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e3a79b4acc832b8b206e6552b24667