### PR TITLE
Update production host references for node checks

### DIFF
--- a/.github/workflows/check-nodes.yml
+++ b/.github/workflows/check-nodes.yml
@@ -6,7 +6,7 @@ on:
       hosts:
         description: "Comma-separated IPv4/hostnames"
         required: true
-        default: "188.245.97.41,188.245.97.42"
+        default: "188.245.97.41,135.181.145.174"
       ui_url:
         description: "Public UI URL (optional)"
         required: false
@@ -24,7 +24,7 @@ on:
     - cron: "30 0 * * *"
 
 env:
-  DEFAULT_HOSTS: "188.245.97.41,188.245.97.42"
+  DEFAULT_HOSTS: "188.245.97.41,135.181.145.174"
   DEFAULT_UI_URL: "https://ui.ippan.org"
   DEFAULT_API_BASE: "http://127.0.0.1:8080"
   DEFAULT_LB_HEALTH: "http://127.0.0.1:3000/lb-health"

--- a/docs/codex-check-nodes.md
+++ b/docs/codex-check-nodes.md
@@ -1,0 +1,39 @@
+# Codex Check Nodes Workflow Instructions
+
+Use the following snippets when triggering the production node health checks.
+
+## Comment for Codex (PR or Issue)
+
+Paste this comment verbatim so Codex runs the workflow with the correct hosts and URLs.
+
+```
+Codex: run the “Check IPPAN Nodes” workflow
+– hosts: 188.245.97.41,135.181.145.174
+– ui_url: https://ui.ippan.org
+– api_base: http://127.0.0.1:8080
+– lb_health: http://127.0.0.1:3000/lb-health
+– Verify services active, /health /status /peers = 200, peer_count > 0, versions match
+– Upload JSON summaries as artifacts and post a pass/fail summary per host
+```
+
+## Issue Body Template (tracking request)
+
+```
+**Targets**
+- env: production
+- hosts:
+  - 188.245.97.41
+  - 135.181.145.174
+```
+
+## Optional: GitHub CLI Trigger
+
+Run the workflow manually from your terminal with the updated defaults.
+
+```bash
+gh workflow run "Check IPPAN Nodes" \
+  -f hosts="188.245.97.41,135.181.145.174" \
+  -f ui_url="https://ui.ippan.org" \
+  -f api_base="http://127.0.0.1:8080" \
+  -f lb_health="http://127.0.0.1:3000/lb-health"
+```


### PR DESCRIPTION
## Summary
- update the Check IPPAN Nodes workflow defaults to target the new production IP pair
- document the Codex comment, tracking issue body, and CLI invocation for the node check workflow

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68e3ad04be4c832b9b92ac5de61bbe3b