### PR TITLE
Add workflow to deploy nodes and Unified UI to production

### DIFF
--- a/.github/workflows/check-nodes.yml
+++ b/.github/workflows/check-nodes.yml
@@ -1,81 +1,68 @@
-name: Check IPPAN Nodes
+name: Check production nodes
 
 on:
   workflow_dispatch:
     inputs:
       hosts:
-        description: "Comma-separated IPv4/hostnames"
-        required: true
+        description: "Comma-separated host list"
+        required: false
         default: "188.245.97.41,135.181.145.174"
       ui_url:
         description: "Public UI URL"
         required: false
         default: "https://ui.ippan.org"
       api_base:
-        description: "Node API base (as seen on target)"
+        description: "API base under the UI (no trailing slash)"
         required: false
-        default: "http://127.0.0.1:8080"
-      lb_health:
-        description: "Load balancer health URL on target"
+        default: "https://ui.ippan.org/api"
+      p2p_port:
+        description: "P2P TCP port"
         required: false
-        default: "http://127.0.0.1:3000/lb-health"
-  schedule:
-    # Nightly run (00:30 UTC). If no inputs (schedule), we fall back to repo vars or literals below.
-    - cron: "30 0 * * *"
+        default: "4001"
 
 jobs:
   check:
     runs-on: ubuntu-latest
-    # Build the matrix from inputs when present, else from repo vars, else hardcoded.
-    strategy:
-      fail-fast: false
-      matrix:
-        host: ${{ fromJson(format('["{0}"]', join('\",\"', split((github.event.inputs.hosts || vars.DEFAULT_HOSTS || '188.245.97.41,135.181.145.174'), ',')))) }}
-
     env:
-      # SSH
-      SSH_USER: ${{ secrets.PROD_SSH_USER }}
-      SSH_KEY:  ${{ secrets.PROD_SSH_KEY }}         # OpenSSH private key
-      SSH_PORT: ${{ secrets.PROD_SSH_PORT || '22' }}
-
-      # Services/paths
-      SYSTEMD_SVC: ippan-node
-      DOCKER_SVC: ippan-node
-      DOCKER_COMPOSE_DIR: /opt/ippan
-      P2P_PORTS: 4001,7000,8080,3000
-
+      HOSTS: ${{ inputs.hosts }}
+      UI_URL: ${{ inputs.ui_url }}
+      API_BASE: ${{ inputs.api_base }}
+      P2P_PORT: ${{ inputs.p2p_port }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Prepare SSH key
+      - name: Parse hosts
+        id: parse
         run: |
-          install -m 700 -d ~/.ssh
-          echo "${SSH_KEY}" > ~/.ssh/id_ed25519
-          chmod 600 ~/.ssh/id_ed25519
-          printf "Host *\n\tStrictHostKeyChecking no\n" > ~/.ssh/config
+          H="${HOSTS// /}"
+          echo "hosts_json=$(printf '[\"%s\"]' \"$(printf '%s' \"$H\" | sed 's/,/","/g')\")" >> $GITHUB_OUTPUT
 
-      - name: Copy checker script
+      - name: DNS/HTTPS sanity
         run: |
-          rsync -e "ssh -i ~/.ssh/id_ed25519 -p ${SSH_PORT}" -avz deploy/check-nodes.sh "${SSH_USER}@${{ matrix.host }}:/tmp/check-nodes.sh"
-          ssh -i ~/.ssh/id_ed25519 -p ${SSH_PORT} "${SSH_USER}@${{ matrix.host }}" "chmod +x /tmp/check-nodes.sh"
+          set -e
+          echo "UI: $UI_URL"
+          curl -fsSLI "$UI_URL" >/dev/null
+          curl -fsSL "$API_BASE/health" | tee health.json
+          jq -e '.status=="healthy"' health.json >/dev/null
 
-      - name: Run checks on ${{ matrix.host }}
-        id: run_checks
-        env:
-          HOST:      ${{ matrix.host }}
-          # Use inputs if present; otherwise repo vars; otherwise literals.
-          UI_URL:    ${{ github.event.inputs.ui_url  || vars.DEFAULT_UI_URL  || 'https://ui.ippan.org' }}
-          API_BASE:  ${{ github.event.inputs.api_base || vars.DEFAULT_API_BASE || 'http://127.0.0.1:8080' }}
-          LB_HEALTH: ${{ github.event.inputs.lb_health || vars.DEFAULT_LB_HEALTH || 'http://127.0.0.1:3000/lb-health' }}
+      - name: Check P2P reachability per host
         run: |
-          set -euo pipefail
-          ssh -i ~/.ssh/id_ed25519 -p ${SSH_PORT} "${SSH_USER}@${{ matrix.host }}" \
-            "HOST='$HOST' UI_URL='$UI_URL' API_BASE='$API_BASE' LB_HEALTH='$LB_HEALTH' SYSTEMD_SVC='${SYSTEMD_SVC}' DOCKER_SVC='${DOCKER_SVC}' DOCKER_COMPOSE_DIR='${DOCKER_COMPOSE_DIR}' P2P_PORTS='${P2P_PORTS}' /tmp/check-nodes.sh" \
-            | tee "summary-${{ matrix.host }}.json"
+          set -e
+          for h in $(echo '${{ steps.parse.outputs.hosts_json }}' | jq -r '.[]'); do
+            echo "Testing TCP ${P2P_PORT} on $h"
+            (echo >/dev/tcp/$h/$P2P_PORT) >/dev/null 2>&1 || {
+              echo "::error::P2P port $P2P_PORT closed on $h"
+              exit 1
+            }
+          done
 
-      - name: Upload summaries
-        uses: actions/upload-artifact@v4
-        with:
-          name: node-summaries
-          path: summary-*.json
+      - name: Check peer_count > 0 after both up
+        run: |
+          set -e
+          curl -fsSL "$API_BASE/health" | jq .
+          peers=$(curl -fsSL "$API_BASE/health" | jq -r '.peer_count // 0')
+          if [ "$peers" -lt 1 ]; then
+            echo "::error::peer_count=$peers (expected > 0 once both nodes are up)"
+            exit 1
+          fi

--- a/.github/workflows/prod-deploy.yml
+++ b/.github/workflows/prod-deploy.yml
@@ -63,6 +63,7 @@ jobs:
           port: ${{ secrets.DEPLOY_PORT }}
           username: ${{ secrets.DEPLOY_USER }}
           key: ${{ secrets.DEPLOY_SSH_KEY }}
+          fingerprint: ${{ secrets.DEPLOY_FINGERPRINT }}
           script: |
             set -euo pipefail
             mkdir -p /opt/ippan/ui
@@ -74,6 +75,7 @@ jobs:
           port: ${{ secrets.DEPLOY_PORT }}
           username: ${{ secrets.DEPLOY_USER }}
           key: ${{ secrets.DEPLOY_SSH_KEY }}
+          fingerprint: ${{ secrets.DEPLOY_FINGERPRINT }}
           source: "ui-dist.tar.gz"
           target: "/opt/ippan/ui"
           overwrite: true
@@ -85,6 +87,7 @@ jobs:
           port: ${{ secrets.DEPLOY_PORT }}
           username: ${{ secrets.DEPLOY_USER }}
           key: ${{ secrets.DEPLOY_SSH_KEY }}
+          fingerprint: ${{ secrets.DEPLOY_FINGERPRINT }}
           script_stop: true
           script: |
             set -euo pipefail
@@ -211,6 +214,7 @@ jobs:
           port: ${{ secrets.DEPLOY_PORT }}
           username: ${{ secrets.DEPLOY_USER }}
           key: ${{ secrets.DEPLOY_SSH_KEY }}
+          fingerprint: ${{ secrets.SECONDARY_FINGERPRINT }}
           script_stop: true
           script: |
             set -euo pipefail

--- a/.github/workflows/prod-deploy.yml
+++ b/.github/workflows/prod-deploy.yml
@@ -1,0 +1,301 @@
+name: Deploy nodes + Unified UI
+
+on:
+  workflow_dispatch:
+
+env:
+  UI_DOMAIN: ui.ippan.org
+  API_HOST_PORT: "7080"
+  P2P_PORT: "4001"
+
+jobs:
+  build-ui:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Install deps
+        working-directory: apps/unified-ui
+        run: npm ci
+
+      - name: Build UI
+        env:
+          NEXT_PUBLIC_API_BASE_URL: ${{ vars.NEXT_PUBLIC_API_BASE_URL }}
+          NEXT_PUBLIC_ENABLE_FULL_UI: ${{ vars.NEXT_PUBLIC_ENABLE_FULL_UI }}
+          NEXT_PUBLIC_GATEWAY_URL: ${{ vars.NEXT_PUBLIC_GATEWAY_URL }}
+          NEXT_PUBLIC_WS_URL: ${{ vars.NEXT_PUBLIC_WS_URL }}
+          GATEWAY_ALLOWED_ORIGINS: ${{ vars.GATEWAY_ALLOWED_ORIGINS }}
+          HEALTH_TIMEOUT_MS: ${{ vars.HEALTH_TIMEOUT_MS }}
+          TARGET_HEALTH_PATH: ${{ vars.TARGET_HEALTH_PATH }}
+          TARGET_RPC_URL: ${{ vars.TARGET_RPC_URL }}
+          TARGET_WS_URL: ${{ vars.TARGET_WS_URL }}
+        working-directory: apps/unified-ui
+        run: npm run build
+
+      - name: Archive dist
+        run: tar -C apps/unified-ui -czf ui-dist.tar.gz dist
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: ui-dist
+          path: ui-dist.tar.gz
+          if-no-files-found: error
+
+  deploy-primary:
+    runs-on: ubuntu-latest
+    needs: build-ui
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: ui-dist
+          path: .
+
+      - name: Ensure remote UI directory exists
+        uses: appleboy/ssh-action@v1.2.0
+        with:
+          host: ${{ secrets.DEPLOY_HOST }}
+          port: ${{ secrets.DEPLOY_PORT }}
+          username: ${{ secrets.DEPLOY_USER }}
+          key: ${{ secrets.DEPLOY_SSH_KEY }}
+          script: |
+            set -euo pipefail
+            mkdir -p /opt/ippan/ui
+
+      - name: Copy UI to server
+        uses: appleboy/scp-action@v0.1.7
+        with:
+          host: ${{ secrets.DEPLOY_HOST }}
+          port: ${{ secrets.DEPLOY_PORT }}
+          username: ${{ secrets.DEPLOY_USER }}
+          key: ${{ secrets.DEPLOY_SSH_KEY }}
+          source: "ui-dist.tar.gz"
+          target: "/opt/ippan/ui"
+          overwrite: true
+
+      - name: Deploy on primary (188.245.97.41)
+        uses: appleboy/ssh-action@v1.2.0
+        with:
+          host: ${{ secrets.DEPLOY_HOST }}
+          port: ${{ secrets.DEPLOY_PORT }}
+          username: ${{ secrets.DEPLOY_USER }}
+          key: ${{ secrets.DEPLOY_SSH_KEY }}
+          script_stop: true
+          script: |
+            set -euo pipefail
+            PUB_IP="${{ secrets.DEPLOY_HOST }}"
+            UI_DOMAIN="${{ env.UI_DOMAIN }}"
+            API_HOST_PORT="${{ env.API_HOST_PORT }}"
+            P2P_PORT="${{ env.P2P_PORT }}"
+
+            apt-get update -y
+            DEBIAN_FRONTEND=noninteractive apt-get install -y docker.io docker-compose-plugin jq ufw nginx
+
+            mkdir -p /opt/ippan && cd /opt/ippan
+
+            mkdir -p /opt/ippan/ui
+            TMP_DIR="/opt/ippan/ui/.tmp-dist"
+            rm -rf "$TMP_DIR"
+            mkdir -p "$TMP_DIR"
+            tar -xzf /opt/ippan/ui/ui-dist.tar.gz -C "$TMP_DIR"
+            if [ -d "$TMP_DIR/dist" ]; then
+              rm -rf /opt/ippan/ui/dist
+              mv "$TMP_DIR/dist" /opt/ippan/ui/dist
+            else
+              rm -rf /opt/ippan/ui/dist
+              mv "$TMP_DIR" /opt/ippan/ui/dist
+            fi
+            rm -rf "$TMP_DIR"
+            rm -f /opt/ippan/ui/ui-dist.tar.gz
+
+            tee docker-compose.override.clear-node-ports.yml >/dev/null <<'YML'
+            services:
+              ippan-node-1:
+                ports: []
+            YML
+
+            tee docker-compose.override.node.yml >/dev/null <<YML
+            services:
+              ippan-node-1:
+                image: ghcr.io/dmrl789/ippan:latest
+                user: "0:0"
+                command:
+                  - sh
+                  - -lc
+                  - |
+                    set -e
+                    echo 'deb http://deb.debian.org/debian bookworm main' > /etc/apt/sources.list.d/bookworm.list
+                    apt-get update -y
+                    apt-get install -y --no-install-recommends -t bookworm libssl3 ca-certificates
+                    exec ippan-node
+                networks:
+                  default:
+                    aliases: [node]
+                environment:
+                  IPPAN_P2P_LISTEN: "/ip4/0.0.0.0/tcp/${P2P_PORT}"
+                  IPPAN_P2P_ANNOUNCE: "/ip4/${PUB_IP}/tcp/${P2P_PORT}"
+                ports:
+                  - "0.0.0.0:${P2P_PORT}:${P2P_PORT}"
+                  - "127.0.0.1:${API_HOST_PORT}:8080"
+            YML
+
+            docker compose -f docker-compose.yml -f docker-compose.full-stack.yml \
+              -f docker-compose.override.clear-node-ports.yml -f docker-compose.override.node.yml \
+              up -d --no-build --no-deps ippan-node-1
+
+            ufw allow ${P2P_PORT}/tcp || true
+            ufw reload || true
+
+            tee /etc/nginx/sites-available/${UI_DOMAIN} >/dev/null <<NGINX
+            server {
+              listen 80;
+              server_name ${UI_DOMAIN};
+              return 301 https://${UI_DOMAIN}\$request_uri;
+            }
+
+            server {
+              listen 443 ssl http2;
+              server_name ${UI_DOMAIN};
+
+              ssl_certificate     /etc/letsencrypt/live/${UI_DOMAIN}/fullchain.pem;
+              ssl_certificate_key /etc/letsencrypt/live/${UI_DOMAIN}/privkey.pem;
+
+              root /opt/ippan/ui/dist;
+              index index.html;
+
+              location /api/ {
+                proxy_pass         http://127.0.0.1:${API_HOST_PORT}/;
+                proxy_http_version 1.1;
+                proxy_set_header   Host \$host;
+                proxy_set_header   X-Forwarded-For \$proxy_add_x_forwarded_for;
+                proxy_set_header   X-Forwarded-Proto \$scheme;
+                proxy_buffering    off;
+              }
+
+              location /ws {
+                proxy_pass         http://127.0.0.1:${API_HOST_PORT}/ws;
+                proxy_http_version 1.1;
+                proxy_set_header   Upgrade \$http_upgrade;
+                proxy_set_header   Connection "upgrade";
+                proxy_set_header   Host \$host;
+                proxy_read_timeout 600s;
+                proxy_send_timeout 600s;
+              }
+
+              location / {
+                try_files \$uri /index.html;
+              }
+            }
+            NGINX
+
+            ln -sf /etc/nginx/sites-available/${UI_DOMAIN} /etc/nginx/sites-enabled/${UI_DOMAIN}
+            nginx -t
+            systemctl enable --now nginx
+            systemctl reload nginx || systemctl restart nginx
+
+            curl -fsSL "http://127.0.0.1:${API_HOST_PORT}/health" | jq .
+
+  deploy-secondary:
+    runs-on: ubuntu-latest
+    needs: deploy-primary
+    steps:
+      - name: Deploy on secondary (135.181.145.174)
+        uses: appleboy/ssh-action@v1.2.0
+        with:
+          host: ${{ vars.SECONDARY_HOST }}
+          port: ${{ secrets.DEPLOY_PORT }}
+          username: ${{ secrets.DEPLOY_USER }}
+          key: ${{ secrets.DEPLOY_SSH_KEY }}
+          script_stop: true
+          script: |
+            set -euo pipefail
+            PUB_IP="${{ vars.SECONDARY_HOST }}"
+            API_HOST_PORT="${{ env.API_HOST_PORT }}"
+            P2P_PORT="${{ env.P2P_PORT }}"
+
+            apt-get update -y
+            DEBIAN_FRONTEND=noninteractive apt-get install -y docker.io docker-compose-plugin jq ufw
+
+            mkdir -p /opt/ippan && cd /opt/ippan
+
+            tee docker-compose.override.clear-node-ports.yml >/dev/null <<'YML'
+            services:
+              ippan-node-1:
+                ports: []
+            YML
+
+            tee docker-compose.override.node.yml >/dev/null <<YML
+            services:
+              ippan-node-1:
+                image: ghcr.io/dmrl789/ippan:latest
+                user: "0:0"
+                command:
+                  - sh
+                  - -lc
+                  - |
+                    set -e
+                    echo 'deb http://deb.debian.org/debian bookworm main' > /etc/apt/sources.list.d/bookworm.list
+                    apt-get update -y
+                    apt-get install -y --no-install-recommends -t bookworm libssl3 ca-certificates
+                    exec ippan-node
+                networks:
+                  default:
+                    aliases: [node]
+                environment:
+                  IPPAN_P2P_LISTEN: "/ip4/0.0.0.0/tcp/${P2P_PORT}"
+                  IPPAN_P2P_ANNOUNCE: "/ip4/${PUB_IP}/tcp/${P2P_PORT}"
+                ports:
+                  - "0.0.0.0:${P2P_PORT}:${P2P_PORT}"
+                  - "127.0.0.1:${API_HOST_PORT}:8080"
+            YML
+
+            docker compose -f docker-compose.yml -f docker-compose.full-stack.yml \
+              -f docker-compose.override.clear-node-ports.yml -f docker-compose.override.node.yml \
+              up -d --no-build --no-deps ippan-node-1
+
+            ufw allow ${P2P_PORT}/tcp || true
+            ufw reload || true
+
+  post-check:
+    runs-on: ubuntu-latest
+    needs: [deploy-primary, deploy-secondary]
+    steps:
+      - name: Verify public UI + health
+        run: |
+          set -euo pipefail
+          curl -fsSLI "https://ui.ippan.org/"
+          HEALTH=$(curl -fsSL "https://ui.ippan.org/api/health")
+          echo "$HEALTH"
+          HEALTH_JSON="$HEALTH" python3 - <<'PY'
+import json, os, sys
+health = json.loads(os.environ["HEALTH_JSON"])
+if health.get("status") != "healthy":
+    print("status != healthy", file=sys.stderr)
+    sys.exit(1)
+PY
+        shell: bash
+
+      - name: Verify P2P reachability (both hosts)
+        run: |
+          set -euo pipefail
+          for h in "${{ secrets.DEPLOY_HOST }}" "${{ vars.SECONDARY_HOST }}"; do
+            echo "Testing P2P $h:4001"
+            (echo >/dev/tcp/$h/4001) >/dev/null 2>&1 || {
+              echo "::error::P2P port 4001 closed on $h"
+              exit 1
+            }
+          done
+
+      - name: Show peer_count
+        run: |
+          set -euo pipefail
+          curl -fsSL "https://ui.ippan.org/api/health" | python3 - <<'PY'
+import json, sys
+health = json.load(sys.stdin)
+print(json.dumps({"peer_count": health.get("peer_count"), "status": health.get("status")}, indent=2))
+PY

--- a/deploy/server/deploy-node.sh
+++ b/deploy/server/deploy-node.sh
@@ -1,0 +1,111 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+PUB_IP="${1:?public_ip}"
+UI_DOMAIN="${2:-ui.ippan.org}"
+API_HOST_PORT="${3:-7080}"
+P2P_PORT="${4:-4001}"
+
+mkdir -p /opt/ippan/deploy
+cd /opt/ippan
+
+apt-get update -y
+DEBIAN_FRONTEND=noninteractive apt-get install -y docker.io docker-compose-plugin jq ufw nginx
+
+tee docker-compose.override.clear-node-ports.yml >/dev/null <<'YML'
+services:
+  ippan-node-1:
+    ports: []
+YML
+
+tee docker-compose.override.node.yml >/dev/null <<YML
+services:
+  ippan-node-1:
+    image: ghcr.io/dmrl789/ippan:latest
+    user: "0:0"
+    command:
+      - sh
+      - -lc
+      - |
+        set -e
+        echo 'deb http://deb.debian.org/debian bookworm main' > /etc/apt/sources.list.d/bookworm.list
+        apt-get update -y
+        apt-get install -y --no-install-recommends -t bookworm libssl3 ca-certificates
+        exec ippan-node
+    networks:
+      default:
+        aliases: [node]
+    environment:
+      IPPAN_P2P_LISTEN: "/ip4/0.0.0.0/tcp/${P2P_PORT}"
+      IPPAN_P2P_ANNOUNCE: "/ip4/${PUB_IP}/tcp/${P2P_PORT}"
+    ports:
+      - "0.0.0.0:${P2P_PORT}:${P2P_PORT}"
+      - "127.0.0.1:${API_HOST_PORT}:8080"
+YML
+
+docker compose -f docker-compose.yml -f docker-compose.full-stack.yml \
+  -f docker-compose.override.clear-node-ports.yml -f docker-compose.override.node.yml up -d --no-build --no-deps ippan-node-1
+
+ufw allow ${P2P_PORT}/tcp || true
+ufw reload || true
+
+if [[ "$PUB_IP" == "188.245.97.41" ]]; then
+  if [[ ! -d /opt/ippan/ui/dist ]]; then
+    mkdir -p /opt/ippan/ui/dist
+    cat >/opt/ippan/ui/dist/index.html <<'HTML'
+<!doctype html><html><head><meta charset="utf-8"><title>IPPAN UI</title></head>
+<body><h1>IPPAN Unified UI</h1><p>Build goes here.</p></body></html>
+HTML
+  fi
+
+  tee /etc/nginx/sites-available/${UI_DOMAIN} >/dev/null <<NGINX
+server {
+  listen 80;
+  server_name ${UI_DOMAIN};
+  return 301 https://${UI_DOMAIN}\$request_uri;
+}
+
+server {
+  listen 443 ssl http2;
+  server_name ${UI_DOMAIN};
+
+  ssl_certificate     /etc/letsencrypt/live/${UI_DOMAIN}/fullchain.pem;
+  ssl_certificate_key /etc/letsencrypt/live/${UI_DOMAIN}/privkey.pem;
+
+  root /opt/ippan/ui/dist;
+  index index.html;
+
+  location /api/ {
+    proxy_pass         http://127.0.0.1:${API_HOST_PORT}/;
+    proxy_http_version 1.1;
+    proxy_set_header   Host \$host;
+    proxy_set_header   X-Forwarded-For \$proxy_add_x_forwarded_for;
+    proxy_set_header   X-Forwarded-Proto \$scheme;
+    proxy_buffering    off;
+  }
+
+  location /ws {
+    proxy_pass         http://127.0.0.1:${API_HOST_PORT}/ws;
+    proxy_http_version 1.1;
+    proxy_set_header   Upgrade \$http_upgrade;
+    proxy_set_header   Connection "upgrade";
+    proxy_set_header   Host \$host;
+    proxy_read_timeout 600s;
+    proxy_send_timeout 600s;
+  }
+
+  location / {
+    try_files \$uri /index.html;
+  }
+}
+NGINX
+
+  ln -sf /etc/nginx/sites-available/${UI_DOMAIN} /etc/nginx/sites-enabled/${UI_DOMAIN}
+  nginx -t
+  systemctl enable --now nginx
+  systemctl reload nginx || systemctl restart nginx
+fi
+
+curl -fsSL "http://127.0.0.1:${API_HOST_PORT}/health" | jq .
+echo "P2P ${P2P_PORT} listening:"
+ss -ltnp | grep ":${P2P_PORT}" || true


### PR DESCRIPTION
## Summary
- add a GitHub Actions workflow to build the unified UI with existing repo variables and archive the dist output
- automate deployment on the primary host including uploading the UI artifact, preparing docker overrides, applying the libssl3 workaround, and refreshing nginx
- roll out the node configuration to the secondary host and add post-deploy health and P2P reachability checks

## Testing
- npm ci (apps/unified-ui)
- npm run build (apps/unified-ui)


------
https://chatgpt.com/codex/tasks/task_e_68e4e636decc832b82ab420f9e6934e5