### PR TITLE
docs: record blocked server health check attempt

### DIFF
--- a/docs/server-health-check.md
+++ b/docs/server-health-check.md
@@ -1,0 +1,19 @@
+# Server Health Check Report
+
+Date: 2025-10-08T07:21:48Z
+
+## Summary
+
+Attempted to query the public health endpoint for the unified UI deployment at `https://ui.ippan.org/health`. The request could not be completed from the current execution environment because the outbound HTTPS tunnel was blocked by a proxy, returning HTTP 403.
+
+## Command Output
+
+```
+curl -sS https://ui.ippan.org/health
+curl: (56) CONNECT tunnel failed, response 403
+```
+
+## Notes
+
+- No additional servers were reachable from this environment, so further health verification steps (checking `/api/health`, `/status`, `/peers`, or load balancer endpoints) could not be executed.
+- Re-run this checklist from an environment with direct network access to the production servers or via the prescribed GitHub workflow (`docs/codex-check-nodes.md`).


### PR DESCRIPTION
## Summary
- add a server health check report documenting the failed attempt to reach https://ui.ippan.org/health
- note the proxy 403 response and next steps for rerunning the checks from a networked environment

## Testing
- not run (documentation-only change)


------
https://chatgpt.com/codex/tasks/task_e_68e60d13fa48832ba2f09b1a6b92a07b