### PR TITLE
chore: automate unified UI asset recovery guidance

### DIFF
--- a/deploy/refresh-ui-assets.sh
+++ b/deploy/refresh-ui-assets.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)
+REPO_ROOT=$(cd -- "${SCRIPT_DIR}/.." && pwd)
+UI_DIR="${REPO_ROOT}/apps/unified-ui"
+DEFAULT_DIST_DIR="${UI_DIR}/dist"
+TARGET_DIST_DIR="${UNIFIED_UI_DIST_DIR:-${DEFAULT_DIST_DIR}}"
+
+log() {
+  printf '[refresh-ui-assets] %s\n' "$*"
+}
+
+die() {
+  printf '[refresh-ui-assets] ERROR: %s\n' "$*" >&2
+  exit 1
+}
+
+command -v npm >/dev/null 2>&1 || die "npm is required but was not found in PATH"
+
+[ -d "${UI_DIR}" ] || die "Unified UI directory not found at ${UI_DIR}"
+
+log "Installing frontend dependencies (npm ci)"
+(
+  cd "${UI_DIR}"
+  export NODE_ENV=production
+  npm ci
+  log "Building production assets (npm run build)"
+  npm run build
+)
+
+if [ "${TARGET_DIST_DIR}" != "${DEFAULT_DIST_DIR}" ]; then
+  log "Preparing custom dist directory at ${TARGET_DIST_DIR}"
+  TARGET_PARENT=$(dirname -- "${TARGET_DIST_DIR}")
+  mkdir -p "${TARGET_PARENT}"
+  rm -rf "${TARGET_DIST_DIR}"
+  cp -R "${DEFAULT_DIST_DIR}" "${TARGET_DIST_DIR}"
+fi
+
+log "Unified UI assets refreshed at ${TARGET_DIST_DIR}"

--- a/docs/server-health-check.md
+++ b/docs/server-health-check.md
@@ -1,19 +1,49 @@
 # Server Health Check Report
 
-Date: 2025-10-08T07:21:48Z
+Date: 2025-10-08T08:12:03Z
 
 ## Summary
 
-Attempted to query the public health endpoint for the unified UI deployment at `https://ui.ippan.org/health`. The request could not be completed from the current execution environment because the outbound HTTPS tunnel was blocked by a proxy, returning HTTP 403.
+- The public unified UI health endpoint at `https://ui.ippan.org/health` is still unreachable from this environment; the outbound proxy blocks the TLS tunnel with HTTP 403 so no live metrics were retrieved.
+- Because `/health` could not be queried, peer connectivity (for example the `peer_count` metric) remains unknown for this run.
+- Unified UI static assets must exist on disk (default: `apps/unified-ui/dist` or the path in `UNIFIED_UI_DIST_DIR`) for the interface to render; when they are missing the node serves JSON APIs only.
 
 ## Command Output
 
 ```
-curl -sS https://ui.ippan.org/health
+curl -I https://ui.ippan.org/health
+HTTP/1.1 403 Forbidden
+content-length: 9
+content-type: text/plain
+date: Wed, 08 Oct 2025 07:56:45 GMT
+server: envoy
+connection: close
+
 curl: (56) CONNECT tunnel failed, response 403
 ```
 
-## Notes
+## Node Connectivity Notes
 
-- No additional servers were reachable from this environment, so further health verification steps (checking `/api/health`, `/status`, `/peers`, or load balancer endpoints) could not be executed.
-- Re-run this checklist from an environment with direct network access to the production servers or via the prescribed GitHub workflow (`docs/codex-check-nodes.md`).
+- Without access to `/health`, peer status could not be confirmed. When connectivity is restored, query the node health endpoint (`http://<rpc-host>:<rpc-port>/health`) and inspect the `peer_count` field—values greater than zero indicate that peers were discovered successfully.
+- If the node reports `peer_count: 0`, ensure that the `BOOTSTRAP_NODES` environment variable supplies the expected peer list before starting the service.
+- To automate the peer check once access is available, run `deploy/check-nodes.sh --rpc http://<rpc-host>:<rpc-port>` and review the emitted table; the script exits non-zero when peers are missing.
+
+## Automated UI Asset Repair
+
+Run the helper script to (re)build the Unified UI assets and copy them to the directory the node serves:
+
+```bash
+deploy/refresh-ui-assets.sh
+```
+
+The script performs `npm ci` and `npm run build` in `apps/unified-ui/`, then copies the resulting `dist` directory to the path defined by `UNIFIED_UI_DIST_DIR` (defaults to `apps/unified-ui/dist`). Re-run the node service afterwards so it can mount the refreshed static files.
+
+## Unified UI Visibility Checklist
+
+- Confirm that the static assets exist on the server (`ls -lah ${UNIFIED_UI_DIST_DIR:-apps/unified-ui/dist}`) and that `index.html` is present.
+- After ensuring the assets exist, restart the node or the serving process so the new files are picked up.
+- If the UI still renders only a short menu, step through `docs/unified_ui_quick_check.md` to validate container health, proxy routing, and environment variables end-to-end.
+
+## Next Steps
+
+Re-run these checks from an environment with direct access to the production servers (for example, via the documented GitHub workflow) to retrieve live health and peer connectivity data.


### PR DESCRIPTION
## Summary
- document the current proxy-blocked health check results and note the automated peer verification script
- add a helper script that rebuilds Unified UI assets and publishes them to the configured dist directory
- extend the UI visibility checklist with asset verification and the quick check playbook

## Testing
- not run (documentation and helper script only)

------
https://chatgpt.com/codex/tasks/task_e_68e61843549c832b9e19e863dece1cd2