### PR TITLE
fix: bundle unified ui assets into docker image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,15 @@
+# Exclude Git metadata and local build artefacts
+.git
+.gitignore
+.github
+Dockerfile.production
+Dockerfile.optimized
+node_modules
+**/node_modules
+target
+**/target
+.tmp
+.vscode
+.idea
+npm-debug.log*
+*.swp


### PR DESCRIPTION
## Summary
- add a node.js build stage to the Dockerfile to compile the Unified UI assets
- copy the built dist directory into the runtime image so ippan-node can serve the UI
- add a .dockerignore to keep node_modules and other local artifacts out of Docker contexts

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e61c922a28832b9128d4d53b043281